### PR TITLE
feat: publish ghcr container packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.kilocode
+.claude
+-old-.opencode
+tmp
+log
+coverage.out

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -27,9 +27,12 @@ jobs:
     steps:
       - name: Resolve release tag
         id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$DISPATCH_TAG"
           else
             VERSION="${GITHUB_REF_NAME}"
           fi
@@ -63,17 +66,19 @@ jobs:
 
       - name: Build image tag list
         id: image
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IMAGE_NAME: ghcr.io/${{ github.repository }}
+          VERSION: ${{ steps.tag.outputs.version }}
+          VERSION_NO_V: ${{ steps.tag.outputs.version_no_v }}
+          PUBLISH_LATEST: ${{ inputs.publish_latest }}
         run: |
-          IMAGE_NAME="ghcr.io/${{ github.repository }}"
-          VERSION="${{ steps.tag.outputs.version }}"
-          VERSION_NO_V="${{ steps.tag.outputs.version_no_v }}"
-
           echo "name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
           {
             echo "tags<<EOF"
             echo "$IMAGE_NAME:$VERSION"
             echo "$IMAGE_NAME:$VERSION_NO_V"
-            if [ "${{ github.event_name }}" = "push" ] || [ "${{ inputs.publish_latest }}" = "true" ]; then
+            if [ "$EVENT_NAME" = "push" ] || [ "$PUBLISH_LATEST" = "true" ]; then
               echo "$IMAGE_NAME:latest"
             fi
             echo "EOF"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,95 @@
+name: Publish Container Package
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (example: v1.0.7)"
+        required: true
+        type: string
+      publish_latest:
+        description: "Also publish :latest"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-ghcr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.tag }}"
+          else
+            VERSION="${GITHUB_REF_NAME}"
+          fi
+
+          if ! echo "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Unsupported tag format: $VERSION"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version_no_v=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.version }}
+
+      - name: Capture source revision
+        id: git
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image tag list
+        id: image
+        run: |
+          IMAGE_NAME="ghcr.io/${{ github.repository }}"
+          VERSION="${{ steps.tag.outputs.version }}"
+          VERSION_NO_V="${{ steps.tag.outputs.version_no_v }}"
+
+          echo "name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
+          {
+            echo "tags<<EOF"
+            echo "$IMAGE_NAME:$VERSION"
+            echo "$IMAGE_NAME:$VERSION_NO_V"
+            if [ "${{ github.event_name }}" = "push" ] || [ "${{ inputs.publish_latest }}" = "true" ]; then
+              echo "$IMAGE_NAME:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push GHCR image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.image.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=Database MCP Server
+            org.opencontainers.image.description=Model Context Protocol provider for SQL databases
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.tag.outputs.version }}
+            org.opencontainers.image.revision=${{ steps.git.outputs.sha }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -55,10 +55,10 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -85,7 +85,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and push GHCR image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: ./Dockerfile

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -72,6 +72,8 @@
 - **Verification**: In-memory client tests confirm tools/list works correctly and capabilities are properly advertised
 
 ## Recent Changes (February 2026)
+- Added GHCR container packaging workflow (`.github/workflows/package.yml`) to publish versioned container images for release tags
+- Added production multi-stage `Dockerfile` and README container usage instructions
 - Implemented F2 Phase 4 MCP handler integration (`schema_tracker.go`)
 - Registered `track-schema-changes` as a public MCP tool
 - Added end-to-end schema tracker tests (`schema_tracker_test.go`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- GHCR container package publishing workflow (`.github/workflows/package.yml`) for version tags and manual backfill.
+- Multi-stage production Dockerfile for publishing `database-mcp-server` images to GitHub Packages.
+- Container usage guidance in README for pulling and running released package images.
+
 ## [v1.0.7] - 2026-02-06
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.7
+
+ARG GO_VERSION=1.25.5
+
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o /out/database-mcp-server ./cmd/server/main.go
+
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata && \
+    addgroup -S app && \
+    adduser -S -G app -u 10001 appuser
+
+WORKDIR /app
+
+COPY --from=builder /out/database-mcp-server /usr/local/bin/database-mcp-server
+
+RUN chown -R appuser:app /app
+
+USER appuser
+
+ENTRYPOINT ["/usr/local/bin/database-mcp-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" \
     go build -trimpath -ldflags="-s -w" -o /out/database-mcp-server ./cmd/server/main.go
 
 FROM alpine:3.21

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
-COPY . .
+COPY cmd ./cmd
+COPY internal ./internal
+COPY pkg ./pkg
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ go build -o mcp-server ./cmd/server/main.go
 ./mcp-server
 ```
 
+## 📦 Container Package (GHCR)
+
+```bash
+# Pull the release image
+docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.0.7
+
+# Run with stdio transport
+docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.0.7
+```
+
+```bash
+# Persist config.yaml and logs on host
+mkdir -p ./.mcp-data
+docker run --rm -i \
+  -v "$(pwd)/.mcp-data:/app" \
+  ghcr.io/guyinwonder168/database-mcp-server:v1.0.7
+```
+
+Package registry: `https://github.com/guyinwonder168/database-mcp-server/pkgs/container/database-mcp-server`
+
 ## 📋 Features
 
 - 🔧 **Interactive Setup** - Auto-creates `config.yaml` if missing; all configuration is managed via MCP actions

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -2,16 +2,17 @@
 
 ## Overview
 
-This document tracks the current implementation status of all features and requirements defined in the PRD. The Database MCP Server is currently in production-ready state with version 1.0.0.
+This document tracks the current implementation status of all features and requirements defined in the PRD. The Database MCP Server is currently in production-ready state with version v1.0.7.
 
 ## Project Information
 
-- **Version:** v1.0.5
-- **Status:** Production Ready with Phase 2 Enhancements in Progress
+- **Version:** v1.0.7
+- **Status:** Production Ready with F2 schema evolution complete and GHCR package publishing enabled
 - **Author:** guyinwonder
 - **Created Using:** OpenAI GPT-4.1 via VSCode Kilocode AI code assistant extension
 - **Last Updated:** February 2026
 - **Toolchain:** Go 1.25.5 (current)
+- **Distribution:** GitHub Releases (tar/zip binaries) + GitHub Packages (GHCR container images)
 
 ## Core Implementation Status
 

--- a/docs/technical-specifications.md
+++ b/docs/technical-specifications.md
@@ -572,18 +572,25 @@ type ErrorResponse struct {
 
 #### Docker Configuration
 ```dockerfile
-FROM golang:1.23-alpine AS builder
-WORKDIR /app
+FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-RUN go build -o mcp-server ./cmd/server/main.go
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o /out/database-mcp-server ./cmd/server/main.go
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
-WORKDIR /root/
-COPY --from=builder /app/mcp-server .
-COPY --from=builder /app/config.yaml .
-CMD ["./mcp-server"]
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates tzdata
+WORKDIR /app
+COPY --from=builder /out/database-mcp-server /usr/local/bin/database-mcp-server
+ENTRYPOINT ["/usr/local/bin/database-mcp-server"]
 ```
+
+Published package image:
+- `ghcr.io/guyinwonder168/database-mcp-server:v1.0.7`
+- `ghcr.io/guyinwonder168/database-mcp-server:latest`
 
 #### Kubernetes Deployment
 ```yaml
@@ -603,7 +610,7 @@ spec:
     spec:
       containers:
       - name: mcp-server
-        image: database-mcp-server:latest
+        image: ghcr.io/guyinwonder168/database-mcp-server:latest
         env:
         - name: DB_MCP_AES_KEY
           valueFrom:


### PR DESCRIPTION
## Summary
This PR adds first-class GitHub Packages publishing for the project by introducing GHCR container image packaging alongside existing GitHub Release binaries.

## Why
- The repository `Packages` tab is currently empty because only Release assets (tar/zip) are published.
- We need a package distribution channel and backfill support for existing tags (`v1.0.5`, `v1.0.6`, `v1.0.7`).

## Changes
- Add production multi-stage container build: `Dockerfile`
- Add docker build context exclusions: `.dockerignore`
- Add GHCR package publishing workflow: `.github/workflows/package.yml`
  - Trigger on tag push: `v*`
  - Manual backfill via `workflow_dispatch` inputs:
    - `tag` (required)
    - `publish_latest` (optional boolean)
  - Publishes multi-arch image: `linux/amd64`, `linux/arm64`
  - Publishes tags:
    - `ghcr.io/<owner>/<repo>:vX.Y.Z`
    - `ghcr.io/<owner>/<repo>:X.Y.Z`
    - optional `:latest`
- Update docs:
  - README container usage section and GHCR package URL
  - Technical spec container deployment example
  - Implementation status distribution notes
  - Changelog Unreleased entry
  - Memory bank context update

## Security/Quality
- Resolved Sonar findings on this PR:
  - Avoid direct use of user-controlled expressions in `run` blocks by using explicit env variables in workflow steps
  - Quote Docker build-arg env expansions in `Dockerfile`

## Validation
- `go test ./...`
- `go vet ./...`

## Rollout
After merge to `main`, run `Publish Container Package` workflow for:
- `v1.0.5`
- `v1.0.6`
- `v1.0.7` (with `publish_latest=true`)

This will populate the GitHub `Packages` tab with historical and latest package tags.
