### PR TITLE
fix(release): set git identity before tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
       - name: Fetch tags
         run: git fetch --tags
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Verify version metadata sync
         run: |
           bash scripts/sync-version-from-server.sh


### PR DESCRIPTION
## Summary
Fixes release workflow failure when creating annotated tags by configuring git identity in GitHub Actions runner.

## Root Cause
Release workflow failed at tag creation with:
- `Committer identity unknown`
- `fatal: empty ident name ... not allowed`

## Changes
- Add `Configure git identity` step in `.github/workflows/release.yml`
- Set:
  - `user.name = github-actions[bot]`
  - `user.email = 41898282+github-actions[bot]@users.noreply.github.com`

## Validation
- Workflow logic reviewed against failed run `21756562617`
- No functional code changes, workflow-only patch

## Expected Result
Next `Release` workflow run on `main` can create/push `v1.1.0` tag and publish GitHub Release assets.