### PR TITLE
fix(release): auto-trigger package publish and fix Dockerfile copy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - main
 
 permissions:
+  actions: write
   contents: write
 
 jobs:
@@ -105,3 +106,14 @@ jobs:
             database-mcp-server_${{ steps.version.outputs.version }}_darwin_amd64.tar.gz
             database-mcp-server_${{ steps.version.outputs.version }}_windows_amd64.zip
           body_path: release-notes.md
+
+      - name: Trigger package publish workflow
+        if: steps.tag.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh workflow run package.yml \
+            --ref main \
+            -f tag="$VERSION" \
+            -f publish_latest=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
-COPY . .
+COPY cmd ./cmd
+COPY internal ./internal
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,7 @@ COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
-COPY cmd ./cmd
-COPY internal ./internal
-COPY pkg ./pkg
+COPY . .
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Summary
This PR fixes the missing automatic package publish for new releases and resolves the Docker build failure in package workflow.

## Root causes
1. Release workflow created tags with `GITHUB_TOKEN`, so tag-push did not trigger package workflow.
2. Dockerfile required `COPY pkg ./pkg`, but `pkg/` may not exist in current tree.

## Changes
- `.github/workflows/release.yml`
  - add `actions: write` permission
  - after successful new release tag creation, dispatch `package.yml` with:
    - `tag=<release version>`
    - `publish_latest=true`
- `Dockerfile`
  - replace selective copy (`cmd`, `internal`, `pkg`) with `COPY . .`
  - keeps `go mod download` layer cache intact, avoids missing-directory build failure

## Validation
- YAML parse check passed for workflows
- `go test ./...` passed
- Docker CLI is not available in this local environment, so image build was validated through workflow logic and prior failing logs only.

## Expected outcome
- Future releases auto-publish GHCR package without manual dispatch.
- GHCR build no longer fails when `pkg/` directory is absent.