### PR TITLE
fix(package): support legacy tag Dockerfile compatibility

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -54,12 +54,19 @@ jobs:
         id: git
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Ensure Dockerfile for legacy tags
+      - name: Ensure Dockerfile compatibility for legacy tags
         run: |
-          if [ -f Dockerfile ]; then
+          # Keep the checked-in Dockerfile when it doesn't require optional pkg/.
+          if [ -f Dockerfile ] && ! grep -Eq 'COPY[[:space:]]+pkg[[:space:]]+\./pkg' Dockerfile; then
             exit 0
           fi
 
+          # Keep the checked-in Dockerfile when pkg/ exists.
+          if [ -f Dockerfile ] && [ -d pkg ]; then
+            exit 0
+          fi
+
+          # Fallback Dockerfile for tags without Dockerfile or with incompatible COPY pkg lines.
           cat > Dockerfile <<'EOF'
           FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine AS builder
           WORKDIR /src


### PR DESCRIPTION
## Summary
Fixes GHCR publish failures when backfilling older tags (including v1.1.0) that contain a Dockerfile requiring `COPY pkg ./pkg` while `pkg/` is absent.

## Root cause
`package.yml` only generated a fallback Dockerfile when Dockerfile was missing. For legacy tags with an incompatible existing Dockerfile, workflow still used that file and failed.

## Changes
- Update `.github/workflows/package.yml` step:
  - keep checked-in Dockerfile when it does **not** require `pkg/`
  - keep checked-in Dockerfile when `pkg/` exists
  - otherwise generate compatibility Dockerfile + .dockerignore fallback

## Validation
- Workflow YAML parse passed
- `go test ./...` passed

## Expected outcome
Manual/package dispatch for `v1.1.0` succeeds and publishes GHCR tags.