### PR TITLE
docs: sync docs and memory bank with runtime v1.1.0

### DIFF
--- a/.kilocode/rules/memory-bank/architecture.md
+++ b/.kilocode/rules/memory-bank/architecture.md
@@ -2,201 +2,80 @@
 
 ## System Architecture Overview
 
-The Database MCP Server follows a layered architecture pattern with clear separation of concerns:
-
-```
-┌─────────────────────────────────────┐
-│         MCP Client (AI Agent)       │
-└─────────────────┬───────────────────┘
-                  │ stdio
-┌─────────────────┴───────────────────┐
-│          MCP Server Layer           │
-│    (internal/mcp/server.go)         │
-├─────────────────────────────────────┤
-│         Business Logic              │
-│  ┌─────────────┬─────────────────┐  │
-│  │   Config    │   Database      │  │
-│  │  Manager    │   Connector     │  │
-│  └─────────────┴─────────────────┘  │
-├─────────────────────────────────────┤
-│         Infrastructure              │
-│  ┌──────┬──────┬────────────────┐   │
-│  │ Log  │ AES  │ DB Drivers     │   │
-│  └──────┴──────┴────────────────┘   │
-└─────────────────────────────────────┘
+```text
+MCP Client
+  -> MCP Server Layer (internal/mcp)
+     -> Config Layer (internal/config)
+     -> DB Layer (internal/db)
+     -> Logging Layer (internal/log)
 ```
 
-## Component Structure
+## Core Components
 
 ### Entry Point
-- **cmd/server/main.go**: Application entry point
-  - Initializes logger
-  - Handles first-run configuration wizard
-  - Starts MCP server
+- `cmd/server/main.go`
+  - startup and transport setup
+  - first-run configuration bootstrap
 
-### Core Components
+### MCP Layer (`internal/mcp`)
+- `server.go`
+  - server initialization
+  - registration of 18 tools
+  - core handlers for profile, SQL, schema, and metadata operations
+- `insights_*.go`
+  - KPI/trend/anomaly/distribution analysis
+- `schema_tracker*.go`, `schema_storage.go`, `schema_migrations.go`
+  - schema snapshots, drift detection, migration generation
+- `federation_*.go`
+  - federated query parsing, planning, execution, result joins
+- `errors.go`
+  - structured error analysis and suggestions
 
-#### MCP Server (internal/mcp/)
-- **server.go**: MCP server implementation
-  - Registers all MCP tools/actions (15 total, fully documented in README)
-  - Routes requests to appropriate handlers
-  - Uses official Go MCP SDK (v1.2.0)
-  - Enhanced error handling with structured error responses and actionable suggestions
-  - Registers MCP resources:
-    - `tools://list` (JSON snapshot of tools registry)
-    - `profile://{profile}` (profile metadata, secrets redacted)
-  - Optional SSE transport: when `MCP_SSE_ADDR` is set, `cmd/server/main.go` starts `mcpsdk.NewSSEHandler` HTTP server alongside stdio.
-  - Handler methods:
-    - handleConfigureProfile
-    - handleListProfiles
-    - handleExecuteSQL (with enhanced read-only enforcement and CTE support)
-    - handleListTables
-    - handleDescribeTable
-    - handleListDatabases
-    - handleMCPInfo
-    - handleSampleData
-    - handleListTools
-    - handleDeleteProfile
-    - handleUpdateProfile
-    - handleAnalyzeSchema (comprehensive analysis with business context inference, data quality metrics, relationship discovery)
-    - handleSmartQueryBuilder (natural language intent processing)
-    - handleDiscoverJoins (foreign key and semantic relationship detection)
-  - Resource handlers:
-    - resourceToolsHandler
-    - resourceProfileHandler
-- **analyze_schema_types.go**: Type system for schema analysis
-  - Comprehensive type definitions for all analysis levels
-  - Business context inference structures
-  - Data quality metrics and pattern recognition
-  - Relationship graph visualization
-  - AI query suggestions integration
-- **errors.go**: Structured error handling system
-  - Error codes and categorization
-  - Actionable suggestions for recovery
-  - Context-aware error messages
-- **server_test.go**: Comprehensive unit tests
-  - Test coverage for all MCP tools
-  - Schema analysis validation tests
-- **tools_list_integration_test.go**: MCP tool discovery regression tests
-  - Prevents future tools/list bugs
-  - Verifies all 15 tools are discoverable by MCP clients
-  - Tests capabilities advertisement and tool registry functionality
+### Configuration Layer (`internal/config`)
+- encrypted profile persistence (AES-GCM)
+- load/save config and first-run defaults
 
-#### Configuration Management (internal/config/)
-- **config.go**: Profile and configuration management
-  - Profile struct: database connection details
-  - Config struct: profiles list, pool size, encryption key
-  - LoadConfig/SaveConfig: YAML file operations
-  - PromptForProfiles: Interactive CLI setup
-  - AES-GCM encryption/decryption helpers
-  - Configuration cleanup: user_key/user_secret fields removed for security and clarity
+### Database Layer (`internal/db`)
+- DSN construction by database type
+- pooled `database/sql` connections
 
-#### Database Abstraction (internal/db/)
-- **driver.go**: Database connection management
-  - OpenConnectionWithPool: Creates pooled connections
-  - DSN: Builds connection strings for different DB types
-  - Supports: MySQL, MariaDB, PostgreSQL, SQLite
+### Logging Layer (`internal/log`)
+- structured JSON logs
+- rotation and controlled stdout behavior
 
-#### Logging (internal/log/)
-- **logger.go**: Structured JSON logging
-  - File rotation (500KB limit)
-  - JSON format with timestamps
-  - Stdout logging disabled by default to avoid MCP stdio contamination; enable via `MCP_LOG_TO_STDOUT=true`
+## Runtime Contracts
 
-## Data Flow
+### Registered Tools (18)
+- `configure-profile`, `list-profiles`, `execute-sql`
+- `list-tables`, `describe-table`, `list-databases`
+- `analyze-schema`, `smart-query-builder`, `discover-joins`, `sample-data`
+- `optimize-query`, `validate-query`, `analyze-data-lineage`, `discover-insights`
+- `track-schema-changes`, `federated-query`
+- `mcp-info`, `list-tools`
 
-### Configuration Flow
-1. Check for config.yaml existence
-2. If missing, run interactive CLI wizard
-3. Encrypt passwords with AES-GCM
-4. Save configuration to YAML file
+### Resources
+- `tools://list` (registered tools snapshot)
+- `profile://{profile}` (redacted profile metadata)
 
-### MCP Action Flow
-1. Receive MCP action request via stdio
-2. Route to appropriate handler
-3. Load configuration
-4. Decrypt credentials
-5. Open database connection (with pooling)
-6. Execute operation
-7. Close connection (return to pool)
-8. Return structured response
+## Architectural Decisions
 
-## Security Architecture
+1. Stateless handler execution for scalability and clarity
+2. Tool-based MCP contracts for interoperability
+3. Read-only policy as first-class guardrail
+4. Separation of concern between handler orchestration and feature-specific engines
 
-### Credential Protection
-- Passwords encrypted using AES-GCM
-- 32-character encryption key required
-- Key stored in config.yaml (should be environment variable in production)
-- No plaintext passwords in memory or logs
+## File Layout (High-Level)
 
-### Access Control
-- Read-only profile flag
-- SQL injection prevention through parameterized queries
-- Connection-level access control (database permissions)
+- `cmd/server/main.go`
+- `internal/config/*`
+- `internal/db/*`
+- `internal/log/*`
+- `internal/mcp/*`
+- `docs/*`
+- `.kilocode/rules/memory-bank/*`
 
-## Design Patterns
+## Source of Truth
 
-1. **Factory Pattern**: Database driver selection based on profile type
-2. **Repository Pattern**: Configuration persistence abstraction
-3. **Command Pattern**: MCP action handlers
-4. **Singleton Pattern**: Logger instance
-5. **Pool Pattern**: Database connection pooling
-
-## File Organization
-
-```
-database-mcp-provider/
-├── cmd/
-│   └── server/
-│       └── main.go           # Entry point
-├── docs/                      # Comprehensive documentation suite
-│   ├── README.md              # Main documentation
-│   ├── prd.md                # Product Requirements Document
-│   ├── prd-analysis-report.md # PRD analysis with AI perspective
-│   ├── technical-specifications.md # Technical architecture details
-│   ├── api-documentation.md # API documentation
-│   ├── mcp-openapi.yaml      # OpenAPI specification
-│   ├── mcp-examples.md       # MCP usage examples
-│   ├── schema-introspection-queries.md # Database-specific queries
-│   ├── smart-query-builder-implementation-plan.md # Query builder design
-│   ├── analyze-schema-design.md # Schema analysis architecture
-│   ├── test-enhanced-schema.md # Test schema documentation
-│   └── implementation-status.md # Implementation tracking
-├── internal/
-│   ├── config/
-│   │   ├── config.go         # Configuration management
-│   │   └── config_template.yaml
-│   ├── db/
-│   │   └── driver.go         # Database abstraction
-│   ├── log/
-│   │   └── logger.go         # Logging infrastructure
-│   └── mcp/
-│       ├── analyze_schema_types.go # Analyze-schema type system
-│       ├── server.go              # MCP server core (all handlers + resources)
-│       ├── errors.go             # Structured error handling
-│       ├── server_test.go         # Comprehensive unit tests
-│       ├── tools_list_integration_test.go # tools/list regression tests
-│       └── integration_live_test.go       # Live Postgres/MySQL smoke tests (env-driven)
-├── go.mod                    # Go module definition (Go 1.25.5 toolchain)
-├── go.sum                    # Dependency lock file
-├── CHANGELOG.md              # Release notes (v1.0.1 includes MCP tool fix, error payload docs, live DB smoke)
-├── config.yaml              # Runtime configuration (generated)
-└── mcp-provider.log         # Runtime logs (generated)
-```
-
-## Critical Implementation Paths
-
-1. **First Run**: main.go → PromptForProfiles → SaveConfig
-2. **Profile Management**: MCP request → handleConfigureProfile → LoadConfig → SaveConfig
-3. **SQL Execution**: MCP request → handleExecuteSQL → OpenConnection → Execute → Return results
-4. **Schema Discovery**: MCP request → handleListTables → Query information_schema → Return metadata
-5. **Sample Data Fetching**: MCP request → handleSampleData → OpenConnection → Execute LIMIT query → Return results
-6. **Tool Enumeration**: MCP request → handleListTools → Dynamic tool registry → Return tool list
-7. **Analyze-Schema**: MCP request → handleAnalyzeSchema → analyze_schema_types.go → OpenConnection → Analyze schema (BASIC/DETAILED/COMPREHENSIVE) → Infer business context, data quality, relationships → Smart Query Builder → Return analysis results
-
-## Documentation and Error Handling
-
-- All 15 MCP tools are fully documented in README.md, including analyze-schema configuration and usage for all supported databases.
-- Enhanced schema introspection, schema analysis, and structured error handling are implemented and documented.
-- Configuration cleanup ensures only relevant fields are present, improving security and maintainability.
-- MCP tool detection fix implemented: Upgraded to Go SDK v1.2.0 (fixing earlier SDK bugs), with comprehensive regression tests to prevent future issues.
+When architecture docs diverge from implementation, defer to:
+1. `internal/mcp/server.go`
+2. `docs/mcp-openapi.yaml`

--- a/.kilocode/rules/memory-bank/brief.md
+++ b/.kilocode/rules/memory-bank/brief.md
@@ -1,42 +1,39 @@
 # Database MCP Server - Project Brief
 
 ## Project Overview
-A production-ready Model Context Protocol (MCP) provider for SQL databases, written in Go. This server enables AI agents and developers to interact with multiple database types through a unified conversational API. All 15 MCP tools (including analyze-schema, validate-query, optimize-query, and analyze-data-lineage) are implemented and comprehensively documented in the README, with configuration and usage examples for MySQL, MariaDB, PostgreSQL, and SQLite.
+
+Database MCP Server is a production-ready MCP provider for SQL databases, implemented in Go. It exposes a unified tool interface so AI agents and developers can safely interact with MySQL, MariaDB, PostgreSQL, and SQLite.
+
+Current implementation state:
+- Version: `v1.1.0`
+- MCP tools: `18` implemented and registered
+- Packaging: GitHub Releases + GHCR container images
 
 ## Core Mission
-Provide a secure, stateless, and unified interface for accessing MySQL, MariaDB, PostgreSQL, and SQLite databases via the Model Context Protocol, abstracting away database-specific complexities. Ensure robust documentation, easy onboarding, and safe credential management.
 
-## Key Requirements
+Provide a secure, practical, and discoverable MCP database interface that works consistently across supported SQL engines and coding clients.
 
-### Functional Requirements
-1. **Multi-Database Support**: MySQL, MariaDB, PostgreSQL, SQLite
-2. **Profile Management**: Create, update, list database connection profiles
-3. **SQL Execution**: Execute arbitrary SQL queries with read-only enforcement option
-4. **Schema Introspection**: List tables/views, describe table schemas, list databases
-5. **Sample Data Fetching**: Fetch sample rows from tables to infer data formats.
-6. **Query Validation**: `validate-query` tool for syntax, logic, and injection pattern checks before execution.
-7. **Interactive Setup**: CLI-based configuration wizard for first-time setup
-8. **Analyze-Schema**: Advanced schema analysis MCP tool supporting BASIC, DETAILED, and COMPREHENSIVE levels, business context inference, data quality metrics, relationship discovery, Smart Query Builder integration
-9. **MCP Actions**: Full suite of 15 MCP tools (including validate-query, optimize-query, and analyze-data-lineage) are documented in README.md
+## Functional Requirements (Current)
 
-### Non-Functional Requirements
-1. **Security**: AES-GCM encryption for stored passwords (32-char key)
-2. **Performance**: Connection pooling with configurable max pool size
-3. **Logging**: Structured JSON logging with file rotation (500KB limit)
-4. **Statelessness**: Each action opens/closes its own connection
-5. **Configuration**: Human-readable YAML configuration file with obsolete user_key/user_secret fields removed
+1. Multi-database connectivity (MySQL, MariaDB, PostgreSQL, SQLite)
+2. Profile configuration and listing (`configure-profile`, `list-profiles`)
+3. SQL execution with read-only policy enforcement (`execute-sql`)
+4. Schema discovery (`list-databases`, `list-tables`, `describe-table`, `discover-joins`)
+5. Data sampling and analysis (`sample-data`, `analyze-schema`, `discover-insights`)
+6. Query intelligence (`smart-query-builder`, `validate-query`, `optimize-query`)
+7. Governance and advanced workflows (`analyze-data-lineage`, `track-schema-changes`, `federated-query`)
+8. Runtime discovery and provider metadata (`list-tools`, `mcp-info`)
 
-## Project Constraints
-- Written in Go (Golang) using the official Go MCP SDK
-- Must work both locally and as a remote server
-- No GUI - CLI and MCP interface only
-- No transaction management beyond atomic operations
-- Relies on database-level permissions for access control
+## Non-Functional Requirements
+
+1. Security: encrypted credentials (AES-GCM), safe logging, read-only guardrails
+2. Performance: pooled connections and efficient stateless handlers
+3. Reliability: structured errors and regression-tested tool registration
+4. Operability: straightforward setup, documented release/package workflow
 
 ## Success Criteria
-- Seamless integration with Kilocode AI, Codex CLI, ClaudeCode and other MCP-compatible systems
-- Zero plaintext credential storage
-- Robust error handling with structured error responses
-- Easy setup process for non-technical users
-- Production-ready reliability and performance
-- Comprehensive documentation for all MCP tools and configuration scenarios
+
+- Reliable cross-client MCP integration (Codex, Claude Code, OpenCode, Kilo, Roo, Cline, Goose, etc.)
+- Zero plaintext credential persistence
+- Practical and accurate documentation aligned with runtime contracts
+- Stable production operation with clear troubleshooting paths

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -2,104 +2,48 @@
 
 ## Current State
 
-### Project Status
-- Version: v1.0.7
-- Author: guyinwonder
-- Created using: OpenAI GPT-4.1 via VSCode Kilocode AI code assistant extension
-- Stage: Production-ready with schema evolution handler integration complete
-- Last Updated: February 2026
-- Toolchain: Go 1.25.7 (default via gvm)
+- Version: `v1.1.0`
+- Stage: Production-ready
+- Toolchain: `go 1.25` with `go1.25.7`
+- MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.2.0`
+- Registered tools: `18`
 
-### Implementation Status
-- ✅ Core MCP server using official Go SDK (v1.2.0, upgraded from v1.1.0)
-- ✅ Multi-database support (MySQL, MariaDB, PostgreSQL, SQLite)
-- ✅ Interactive CLI setup wizard with auto-configuration
-- ✅ Profile management (create, list, update, delete)
-- ✅ SQL execution with enhanced read-only enforcement and multi-statement protection
-- ✅ Schema introspection (list tables, describe table, list databases) with comprehensive metadata
-- ✅ Sample data fetching from tables with configurable limits
-- ✅ AES-GCM password encryption (32-char key) with auto-generation
-- ✅ Connection pooling with configurable limits
-- ✅ Structured JSON logging with rotation and credential redaction
-- ✅ 17 MCP tools implemented and documented:
-  - configure-profile, list-profiles, execute-sql
-  - list-tables, describe-table, list-databases
-  - analyze-schema (with 3 analysis levels)
-  - smart-query-builder, discover-joins, sample-data
-  - mcp-info, list-tools
-  - optimize-query, validate-query
-  - analyze-data-lineage, discover-insights
-  - track-schema-changes
-- ✅ Schema evolution implementation completed for `track-schema-changes`:
-  - Phase 1: snapshot/types (`schema_snapshot_types.go`)
-  - Phase 2: snapshot storage and diff/drift detection (`schema_storage.go`)
-  - Phase 3: migration generator (`schema_migrations.go`)
-  - Phase 4: MCP handler integration and tool registration (`schema_tracker.go`)
-- ✅ Valid JSON Schema for tool parameters (`params` arrays)
-- ✅ Documentation for base64-encoded BLOB/BINARY parameters
-- ✅ Comprehensive error analysis with structured error responses and actionable suggestions
-- ✅ Enhanced analyze-schema implementation:
-  - Business context inference and domain detection
-  - Data quality metrics with scoring
-  - Relationship discovery (FK + semantic)
-  - Smart Query Builder integration
-  - Pattern recognition and validation
-- ✅ Advanced security features:
-  - Credential redaction in logs
-  - Enhanced SQL injection prevention
-  - Read-only profile enforcement with CTE support
-- ✅ MCP resources added:
-  - `tools://list` (JSON snapshot of registered tools)
-  - `profile://{profile}` (profile metadata with secrets redacted)
-- ✅ Optional HTTP/SSE transport: enable via `MCP_SSE_ADDR` (Claude: point provider to http://localhost:PORT; Codex: use if SSE supported, else stdio; Kilocode: prefers stdio unless testing SSE)
-- ✅ Logging: stdout disabled by default to avoid MCP stdio contamination; enable via `MCP_LOG_TO_STDOUT=true`
-- ✅ Live DB smoke tests: Postgres and MySQL/MariaDB via env vars `DB_MCP_IT_*`
-- ✅ Codex/Kilocode tool discovery confirmed (16 tools visible)
+## Implemented Capabilities
 
-### Documentation Enhancements
-- ✅ Consolidated enhancement roadmap into docs/roadmap.md
-- ✅ Updated documentation links to the consolidated roadmap
-- ✅ Planning history preserved in docs/history
+- Core DB workflow:
+  - `configure-profile`, `list-profiles`, `execute-sql`
+  - `list-databases`, `list-tables`, `describe-table`
+  - `discover-joins`, `sample-data`
+- Query intelligence:
+  - `smart-query-builder`, `validate-query`, `optimize-query`
+- Analysis/governance:
+  - `analyze-schema` (with optional profiling)
+  - `analyze-data-lineage`
+  - `discover-insights`
+  - `track-schema-changes` (track/history/generate_migration/detect_drift)
+  - `federated-query`
+- Runtime metadata:
+  - `list-tools`, `mcp-info`
 
-### Known Issues
-- None identified
+## Packaging and Release State
 
-### MCP Tool Detection Fix (December 2024, validated Dec 2025)
-- **Critical Issue Resolved**: MCP Go SDK v0.2.0 had a broken `tools/list` method that prevented MCP clients from discovering any tools
-- **Solution Applied**: Upgraded to MCP Go SDK v1.1.0 which fixes the tools/list routing bug
-- **Testing Added**: Comprehensive regression tests in `internal/mcp/tools_list_integration_test.go` to prevent future regressions
-- **Impact**: All 12 MCP tools are now discoverable by MCP clients (Codex, Kilocode, Claude Desktop)
-- **Verification**: In-memory client tests confirm tools/list works correctly and capabilities are properly advertised
+- Release workflow publishes GitHub Releases from tags
+- Package workflow publishes GHCR container images
+- Latest release line currently aligned at `v1.1.0`
 
-## Recent Changes (February 2026)
-- Added GHCR container packaging workflow (`.github/workflows/package.yml`) to publish versioned container images for release tags
-- Added production multi-stage `Dockerfile` and README container usage instructions
-- Implemented F2 Phase 4 MCP handler integration (`schema_tracker.go`)
-- Registered `track-schema-changes` as a public MCP tool
-- Added end-to-end schema tracker tests (`schema_tracker_test.go`)
-- Implemented F2 Phase 3 migration generator (`schema_migrations.go`)
-- Added migration generator test coverage (`schema_migrations_test.go`)
-- Added SQL conversion, validation, and impact estimation utilities for schema diffs
-- Updated roadmap/TDD/docs status to reflect F2 phase progress
-- Upgraded Go SDK to v1.2.0
-- Fixed JSON Schema for tool parameters to avoid validation errors
-- Added documentation for BLOB/BINARY base64 encoding
-- Updated project implementation status and roadmap tracking
-- Version bumped to v1.0.7
+## Documentation State
 
-## Recent Changes (January 2026)
-- Consolidated enhancement roadmap into docs/roadmap.md
-- Moved legacy planning docs into docs/history for reference
-- Updated documentation links to point at the consolidated roadmap
-- Recorded optimize/validate/lineage completions and current NLP work in roadmap
-- Memory bank refreshed for v1.0.2
+- Root README aligned with `v1.1.0` and 18 tools
+- docs/ updated to reflect current runtime behavior
+- Wiki expanded with onboarding, tool-scenario mapping, and client setup guides
 
-## Next Steps
+## Key Historical Context
 
-### Immediate Priorities
-- Start F3 advanced profiling enhancements for `analyze-schema`
-- Monitor for bug reports and user feedback
+- Previous MCP `tools/list` discoverability issue was resolved by SDK upgrades and regression tests
+- F1-F4 roadmap slices are implemented and merged
 
-### Future Enhancements
-- Advanced data profiling
-- Multi-database federation
+## Immediate Priorities
+
+1. Maintain documentation/runtime parity for future changes
+2. Keep coverage and CI quality gates stable
+3. Maintain release and package automation health

--- a/.kilocode/rules/memory-bank/product.md
+++ b/.kilocode/rules/memory-bank/product.md
@@ -2,61 +2,55 @@
 
 ## Why This Project Exists
 
-### Problem Statement
-Developers and AI agents face significant challenges when working with multiple databases:
-- Different SQL dialects and connection protocols for each database type
-- Complex driver management and authentication handling
-- No unified interface for AI systems to interact with databases
-- Security concerns with credential management
-- Difficulty in providing database access to AI assistants safely
+Developers and AI agents often need database access across different SQL engines, but integration is usually fragmented and unsafe when done ad hoc.
 
-### Solution
-The Database MCP Server provides a unified conversational API that allows AI agents and developers to interact with any supported SQL database through standardized MCP actions, abstracting away database-specific complexities. All 15 MCP tools and configuration scenarios are comprehensively documented, with usage examples for MySQL, MariaDB, PostgreSQL, and SQLite.
+Database MCP Server provides a unified MCP tool interface with consistent behavior and safety controls.
+
+## Product Value
+
+- One interface across MySQL, MariaDB, PostgreSQL, SQLite
+- Structured tool contracts for agent workflows
+- Secure credential handling and read-only execution controls
+- Practical discovery + intelligence + governance workflows in one server
 
 ## How It Works
 
-### Core Workflow
-1. **Initial Setup**: On first run, interactive CLI guides users through creating database profiles
-2. **Profile Management**: Users can add/update database connections via MCP actions
-3. **Query Execution**: AI agents execute SQL queries through the `execute-sql` action
-4. **Schema Discovery**: Agents can explore database structure via introspection actions
-5. **Sample Data Fetching**: Agents can fetch sample rows to infer data formats and value ranges.
-6. **Secure Operation**: All credentials encrypted at rest, connections managed per-action
+1. Client calls an MCP tool
+2. Server validates parameters and policy (including read-only mode)
+3. Server executes DB operation via selected profile
+4. Structured response is returned to the client
 
-### User Experience Goals
+## User Outcomes
 
-#### For Developers
-- **Zero Configuration Start**: Interactive setup wizard for first-time users
-- **Simple Integration**: Works with any MCP-compatible system
-- **Clear Error Messages**: Structured JSON errors for easy debugging
-- **Flexible Security**: Read-only mode for safe exploration
-- **Comprehensive Documentation**: All MCP tools and configuration scenarios are fully documented for easy onboarding
+### For Developers
+- Faster onboarding to unfamiliar databases
+- Less manual wiring across tools and drivers
+- Better query quality through validate/optimize flow
 
-#### For AI Agents
-- **Consistent Interface**: Same actions work across all database types
-- **Discoverable Schema**: Can explore tables and columns programmatically
-- **Sample Data**: Can fetch sample rows to understand data formats and values before querying.
-- **Safe Operations**: Read-only enforcement prevents accidental data loss
-- **Contextual Responses**: Rich metadata in all responses
+### For AI Agents
+- Discoverable capabilities via `list-tools`
+- Schema-aware SQL workflows
+- Reliable structured responses for chaining tasks
 
-#### For System Administrators
-- **Secure by Default**: Encrypted credential storage
-- **Auditable**: Structured JSON logging of all operations
-- **Resource Efficient**: Connection pooling prevents resource exhaustion
-- **Easy Deployment**: Single binary, YAML configuration
+### For Teams/Admins
+- Safer defaults for exploratory access
+- Centralized profile and operation model
+- Better maintainability of agent-db integrations
 
-## Target Use Cases
+## Supported Tool Surface
 
-1. **AI-Powered Data Analysis**: Enable AI assistants to query and analyze data
-2. **Database Documentation**: AI agents can generate documentation from schema
-3. **Data Validation**: Automated checking of data integrity across systems
-4. **Report Generation**: AI-driven report creation from database queries
-5. **Development Assistance**: Help developers understand unfamiliar databases
+The product currently exposes 18 tools, spanning:
+- profile/connectivity,
+- schema discovery,
+- SQL execution,
+- query intelligence,
+- lineage/insight/schema governance,
+- cross-profile federation,
+- runtime metadata.
 
 ## Success Metrics
-- Time to first successful query < 5 minutes
-- Zero plaintext passwords in configuration
-- All database operations complete in < 5 seconds
-- 100% compatibility with MCP specification
-- Clear error messages for all failure scenarios
-- Comprehensive, up-to-date documentation for all features
+
+- Low time-to-first-query for new users
+- Stable MCP integration across major coding clients
+- No plaintext credential storage
+- Up-to-date documentation synchronized with runtime contracts

--- a/.kilocode/rules/memory-bank/tech.md
+++ b/.kilocode/rules/memory-bank/tech.md
@@ -1,195 +1,64 @@
 # Database MCP Server - Technology Stack
 
-## Core Technologies
+## Core Stack
 
-### Programming Language
-- **Go (Golang)** - Version 1.25.5
-  - Chosen for performance, strong typing, and excellent concurrency support
-  - Toolchain: go1.25.5 (gvm default; 1.25.4 removed)
+### Language and Toolchain
+- Go module baseline: `go 1.25`
+- Toolchain: `go1.25.7`
 
-### MCP Framework
-- **Official Go MCP SDK** (github.com/modelcontextprotocol/go-sdk v1.2.0)
-  - Model Context Protocol implementation
-  - Stdio transport for local communication
-  - JSON-RPC protocol support
-  - Upgraded to v1.2.0 for latest features and stability
+### MCP SDK
+- `github.com/modelcontextprotocol/go-sdk v1.2.0`
 
 ### Database Drivers
-- **MySQL/MariaDB**: github.com/go-sql-driver/mysql v1.9.3
-- **PostgreSQL**: github.com/lib/pq v1.10.9
-- **SQLite**: github.com/mattn/go-sqlite3 v1.14.30
-- All use standard `database/sql` interface
+- MySQL/MariaDB: `github.com/go-sql-driver/mysql v1.9.3`
+- PostgreSQL: `github.com/lib/pq v1.11.1`
+- SQLite: `github.com/mattn/go-sqlite3 v1.14.33`
 
-### Supporting Libraries
-- **YAML Configuration**: gopkg.in/yaml.v3 v3.0.1
-- **Log Rotation**: github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
-- **Encryption**: Standard library crypto/aes for AES-GCM
-- **Additional Dependencies**:
-  - filippo.io/edwards25519 v1.1.0 // indirect
-  - github.com/jonboulle/clockwork v0.5.0 // indirect
-  - github.com/lestrrat-go/strftime v1.1.1 // indirect
-  - github.com/pkg/errors v0.9.1 // indirect
-  - github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-  - github.com/blastrain/vitess-sqlparser v0.0.0-20201030050434-a139afbb1aba (SQL validation)
+### Other Key Dependencies
+- YAML config: `gopkg.in/yaml.v3`
+- JSON schema helper: `github.com/google/jsonschema-go`
+- SQL parser support: `github.com/blastrain/vitess-sqlparser`
+- Log rotation: `github.com/lestrrat-go/file-rotatelogs`
 
-## Development Setup
+## Runtime Model
 
-### Prerequisites
+- Default transport: stdio
+- Optional transport: HTTP/SSE via `MCP_SSE_ADDR`
+- Configuration: `config.yaml` (auto-created if missing)
+- Logs: structured JSON with rotation
+
+## Security and Policy
+
+- AES-GCM password encryption
+- Per-profile read-only mode
+- Parameterized query support for execution paths
+
+## Build and Test Commands
+
 ```bash
-# Go 1.25.5
-go version
-
-# Git for version control
-git --version
-```
-
-### Build Instructions
-```bash
-# Clone repository
-git clone [repository-url]
-cd database-mcp-provider
-
-# Download dependencies
-go mod download
-
-# Build the server
-go build -o mcp-server ./cmd/server/main.go
-
-# Run tests
+go build -o ./tmp/mcp-server ./cmd/server/main.go
 go test ./...
+go test -cover ./...
+go vet ./...
 ```
 
-### Configuration
-1. **First Run**: Interactive CLI wizard guides through setup
-2. **Manual Configuration**: Edit `config.yaml`
-   ```yaml
-   max_pool_size: 10
-   aes_key: "<32-character-string>"
-   profiles:
-     - profile_name: "mydb"
-       db_type: "postgres"
-       host: "localhost"
-       port: 5432
-       username: "user"
-       password: "<encrypted>"
-       database_name: "database"
-       readonly: false
-   ```
-   - Configuration cleanup: obsolete user_key/user_secret fields have been removed for security and clarity.
-   - All database profile examples (MySQL, MariaDB, PostgreSQL, SQLite) are included in the documentation.
+Optional live integration tests:
 
-### Environment Variables
-- **DB_MCP_AES_KEY**: Optional, overrides config file AES key
-- **MCP_LOG_TO_STDOUT**: Set to `true` to mirror logs to stdout (defaults to file-only to keep MCP stdio clean)
-- Live DB smoke tests:
-  - Postgres: `DB_MCP_IT_PG_HOST`, `DB_MCP_IT_PG_PORT`, `DB_MCP_IT_PG_USER`, `DB_MCP_IT_PG_PASS`, `DB_MCP_IT_PG_DB`, `DB_MCP_IT_PG_SSLMODE`
-  - MySQL/MariaDB: `DB_MCP_IT_MYSQL_HOST`, `DB_MCP_IT_MYSQL_PORT`, `DB_MCP_IT_MYSQL_USER`, `DB_MCP_IT_MYSQL_PASS`, `DB_MCP_IT_MYSQL_DB`
-- Standard database environment variables respected by drivers
-- **MCP_SSE_ADDR**: Optional; set to host:port (e.g., `:8080`) to serve MCP over HTTP/SSE alongside stdio. Example: `MCP_SSE_ADDR=":8080" ./mcp-server`
-
-## Technical Constraints
-
-### Security
-- AES-256-GCM encryption mandatory for passwords
-- No plaintext credentials in logs or config
-- SQL injection prevention via parameterized queries
-
-### Performance
-- Connection pooling with configurable limits
-- Stateless design for scalability
-- JSON structured logging for efficient parsing
-
-### Compatibility
-- Works with MCP-compatible clients (Kilocode AI, etc.)
-- Database version requirements:
-  - MySQL 5.7+
-  - MariaDB 10.2+
-  - PostgreSQL 10+
-  - SQLite 3.8.0+
-
-## Development Patterns
-
-### Code Organization
-- **cmd/**: Entry points
-- **internal/**: Private packages
-- **config/**: Configuration management
-- **db/**: Database abstraction
-- **log/**: Logging infrastructure
-- **mcp/**: MCP server implementation
-
-### Testing Strategy
-- Unit tests for individual components
-- Integration tests with test databases
-- Mock MCP client for end-to-end testing
-
-### Error Handling
-- Structured error responses
-- Detailed logging for debugging
-- User-friendly error messages
-
-## Deployment
-
-### Local Development
 ```bash
-./mcp-server
+DB_MCP_IT_PG_HOST=... DB_MCP_IT_PG_DB=... go test ./internal/mcp -run TestLive -count=1
 ```
 
-### Production Deployment
-1. Set secure AES key via environment variable
-2. Configure appropriate pool sizes
-3. Set up log rotation and monitoring
-4. Use systemd or similar for process management
-5. Optional SSE transport: set `MCP_SSE_ADDR` (e.g., `:8080`) to serve MCP over HTTP/SSE alongside stdio.
+## Packaging
 
-### Integration with Kilocode AI
-```yaml
-mcp_providers:
-  - name: database-mcp
-    type: process
-    command: /path/to/mcp-server
-    working_dir: /path/to/config
-    auto_start: true
-```
+- GitHub Releases for binaries
+- GHCR package: `ghcr.io/guyinwonder168/database-mcp-server`
 
-## Monitoring & Debugging
+## Current Capability Surface
 
-### Logs
-- Location: `mcp-provider.log`
-- Format: Structured JSON
-- Rotation: 500KB file size limit
-- Retention: 7 days
-- Stdout logging disabled by default; enable via `MCP_LOG_TO_STDOUT=true` to mirror logs (kept off to avoid MCP stdio contamination)
+- 18 MCP tools implemented
+- Full coverage of profile management, schema discovery, SQL execution, intelligence tools, schema tracking, and federation
 
-### Debug Commands
-```bash
-# Test configuration
-./mcp-server --test-config
+## Source of Truth
 
-# Verbose logging
-./mcp-server --verbose
-
-# Check MCP info
-echo '{"method":"mcp-info"}' | ./mcp-server
-```
-
-## Dependencies Management
-
-### Update Dependencies
-```bash
-go get -u ./...
-go mod tidy
-```
-
-### Security Scanning
-```bash
-go list -m -json all | nancy sleuth
-```
-
-## Known Technical Limitations
-- No GUI interface (CLI and MCP only)
-- Single transaction per action (no multi-statement transactions)
-- Connection pool per process (not shared across instances)
-
-## Documentation
-
-- README.md provides comprehensive documentation for all 12 MCP tools, configuration scenarios, and usage examples for all supported databases.
+- Runtime contracts: `internal/mcp/server.go`
+- API schema: `docs/mcp-openapi.yaml`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,216 +1,70 @@
-# Database MCP Server - Documentation
+# Database MCP Server Documentation
 
 ## Overview
 
-This directory contains comprehensive documentation for the Database MCP Server project. The documentation is organized into focused documents to serve different audiences and purposes.
+This directory contains the canonical project documentation for the current production state.
 
-**Current Status**: Production-ready with 12 comprehensive MCP tools, with enhancement roadmap in progress for AI-focused capabilities. Toolchain: Go 1.25.5.
+Current baseline:
+- Version: `v1.1.0`
+- MCP tools: `18` implemented and registered
+- Databases: MySQL, MariaDB, PostgreSQL, SQLite
+- Go baseline: `go 1.25` with toolchain `go1.25.7`
 
-## Documentation Structure
+## Document Index
 
-### Core Product Documents
+### Core
 
-#### [Product Requirements Document (PRD)](prd.md)
-- **Purpose**: Defines product requirements, user personas, and success criteria
-- **Audience**: Product managers, stakeholders, developers
-- **Content**: Functional requirements, user stories, business context
+- [implementation-status.md](implementation-status.md)
+  - Current feature/tool status and release state.
+- [api-documentation.md](api-documentation.md)
+  - Runtime tool contracts and usage patterns.
+- [technical-specifications.md](technical-specifications.md)
+  - Architecture, runtime model, and operational constraints.
+- [mcp-openapi.yaml](mcp-openapi.yaml)
+  - Machine-readable API schema for tooling and validation.
+- [mcp-examples.md](mcp-examples.md)
+  - Practical request/response examples.
+- [roadmap.md](roadmap.md)
+  - Consolidated roadmap (reflects delivered phases).
+- [tdd-implementation-plan.md](tdd-implementation-plan.md)
+  - TDD implementation record and hardening checklist.
 
-#### [Implementation Status](implementation-status.md)
-- **Purpose**: Tracks current implementation status against PRD requirements
-- **Audience**: Project managers, developers, QA teams
-- **Content**: Feature completion status, testing coverage, known issues
+### Product/Design
 
-#### [Enhancement Roadmap](roadmap.md)
-- **Purpose**: High-level strategic overview of planned enhancements
-- **Audience**: Product managers, stakeholders, development teams
-- **Content**: Enhancement phases, status, strategic vision
+- [prd.md](prd.md)
+  - Product requirements and long-term direction.
+- [analyze-schema-design.md](analyze-schema-design.md)
+  - Detailed design for analyze-schema orchestration.
+- [schema-introspection-queries.md](schema-introspection-queries.md)
+  - DB-specific introspection query references.
 
-### Technical Documentation
+### History (Reference)
 
-#### [Technical Specifications](technical-specifications.md)
-- **Purpose**: Detailed technical implementation details
-- **Audience**: Developers, architects, technical leads
-- **Content**: System architecture, data models, algorithms, performance
+- [history/](history/)
+  - Historical plans and migration context. These files are preserved as historical snapshots and may describe earlier phases.
 
-#### [API Documentation](api-documentation.md)
-- **Purpose**: Complete API reference for all MCP tools
-- **Audience**: Developers, integration teams, API users
-- **Content**: Request/response formats, examples, error codes
+## Source of Truth Rules
 
-#### [System Architecture](../.kilocode/rules/memory-bank/architecture.md)
-- **Purpose**: High-level system architecture overview
-- **Audience**: Architects, senior developers
-- **Content**: Component relationships, design patterns, data flow
+When docs conflict, use this precedence:
+1. Runtime implementation (`internal/mcp/server.go`)
+2. OpenAPI spec (`docs/mcp-openapi.yaml`)
+3. This docs folder markdown
 
-### Specialized Documentation
+Version/source of truth:
+- Runtime version string: `internal/mcp/server.go` (`MCPVersion`)
+- Release tags/packages: GitHub Releases + GHCR
 
-#### [Analyze Schema Design](analyze-schema-design.md)
-- **Purpose**: Detailed design of schema analysis functionality
-- **Audience**: Developers working on schema analysis features
-- **Content**: Type system, analysis algorithms, business context inference
+## Documentation Maintenance
 
-#### [MCP Examples](mcp-examples.md)
-- **Purpose**: Practical examples of MCP tool usage
-- **Audience**: Users, developers, integration teams
-- **Content**: Real-world usage scenarios, code examples
+Update docs in the same PR as code changes when any of these change:
+- tool contracts (name/params/output)
+- supported databases or behavior
+- runtime version
+- packaging/release workflow
 
-#### [Schema Introspection Queries](schema-introspection-queries.md)
-- **Purpose**: Database-specific schema query implementations
-- **Audience**: Developers, database administrators
-- **Content**: SQL queries for each supported database type
-
-#### [Smart Query Builder Implementation](smart-query-builder-implementation-plan.md)
-- **Purpose**: Technical details of natural language to SQL conversion
-- **Audience**: Developers working on query building features
-- **Content**: Algorithms, parsing logic, optimization strategies
-
-#### [Test Enhanced Schema](test-enhanced-schema.md)
-- **Purpose**: Testing strategy for enhanced schema features
-- **Audience**: QA teams, developers
-- **Content**: Test cases, validation procedures, quality metrics
-
-#### [MCP OpenAPI Specification](mcp-openapi.yaml)
-- **Purpose**: Machine-readable API specification
-- **Audience**: API tools, documentation generators
-- **Content**: OpenAPI/YAML specification of all MCP tools
-
-### Planning and Roadmap Documents
-
-#### [Project Plan (History)](history/project-plan-roadmap.md)
-- **Purpose**: Comprehensive implementation plan based on PRD analysis
-- **Audience**: Development teams, project managers, architects
-- **Content**: Detailed enhancement roadmap, technical architecture, success metrics
-
-#### [Vertical Slices (History)](history/vertical-slices.md)
-- **Purpose**: Detailed vertical slice definitions for implementation phases
-- **Audience**: Developers, technical leads, QA teams
-- **Content**: Slice-by-slice breakdown, deliverables, success criteria, dependencies
-
-#### [Implementation Tasks (History)](history/implementation-tasks.md)
-- **Purpose**: Task-by-task breakdown for each vertical slice
-- **Audience**: Development team, project managers
-- **Content**: Detailed subtasks, time estimates, file modifications, acceptance criteria
-
-## Quick Navigation
-
-### For Product Managers
-1. Start with [PRD](prd.md) to understand requirements
-2. Review [Implementation Status](implementation-status.md) for progress tracking
-3. Check [Enhancement Roadmap](roadmap.md) for strategic direction
-4. Review [Project Plan (History)](history/project-plan-roadmap.md) for detailed implementation strategy
-5. Check [Technical Specifications](technical-specifications.md) for feasibility
-
-### For Developers
-1. Read [Technical Specifications](technical-specifications.md) for architecture
-2. Use [API Documentation](api-documentation.md) for integration
-3. Reference [System Architecture](../.kilocode/rules/memory-bank/architecture.md) for design patterns
-4. Review [Vertical Slices (History)](history/vertical-slices.md) for implementation approach
-5. Use [Implementation Tasks (History)](history/implementation-tasks.md) for detailed task breakdown
-
-### For Users/Integrators
-1. Start with [MCP Examples](mcp-examples.md) for quick start
-2. Use [API Documentation](api-documentation.md) for reference
-3. Check [Implementation Status](implementation-status.md) for feature availability
-4. Review [Enhancement Roadmap](roadmap.md) for upcoming features
-
-### For QA Teams
-1. Review [Implementation Status](implementation-status.md) for test coverage
-2. Use [Test Enhanced Schema](test-enhanced-schema.md) for testing strategies
-3. Reference [API Documentation](api-documentation.md) for test cases
-
-## Document Maintenance
-
-### Version Control
-- All documentation is version-controlled with the main project
-- Document versions align with software releases
-- Change history maintained in individual documents
-
-### Update Process
-1. **PRD Updates**: When requirements change
-2. **Implementation Status**: When features are completed
-3. **Technical Specs**: When architecture changes
-4. **API Documentation**: When APIs are modified
-
-### Review Schedule
-- **Monthly**: Review and update implementation status
-- **Quarterly**: Review and update PRD requirements
-- **As Needed**: Update technical documentation for changes
-
-## Getting Started
-
-### New Team Members
-1. Read [PRD](prd.md) for product understanding
-2. Review [System Architecture](../.kilocode/rules/memory-bank/architecture.md) for technical context
-3. Study [Technical Specifications](technical-specifications.md) for implementation details
-
-### Integration Teams
-1. Start with [MCP Examples](mcp-examples.md) for quick integration
-2. Use [API Documentation](api-documentation.md) for detailed reference
-3. Check [Implementation Status](implementation-status.md) for feature availability
-
-### Contributors
-1. Review [Technical Specifications](technical-specifications.md) before making changes
-2. Update relevant documentation when implementing features
-3. Follow documentation standards and formatting
-
-## Documentation Standards
-
-### Formatting
-- **Markdown**: All documents use GitHub-flavored markdown
-- **Code Blocks**: Syntax highlighting for all code examples
-- **Links**: Relative links for internal navigation
-- **Images**: Optimized images with alt text
-
-### Content Standards
-- **Clarity**: Clear, concise language appropriate for audience
-- **Completeness**: Comprehensive coverage of topics
-- **Accuracy**: Technical accuracy and up-to-date information
-- **Examples**: Practical, tested examples
-
-### Review Process
-1. **Technical Review**: Accuracy and completeness
-2. **Peer Review**: Clarity and usability
-3. **Editorial Review**: Grammar, spelling, formatting
-4. **Final Approval**: Document owner sign-off
-
-## Support and Feedback
-
-### Getting Help
-- **Technical Issues**: Check [API Documentation](api-documentation.md) error codes
-- **Implementation Questions**: Review [Technical Specifications](technical-specifications.md)
-- **Product Questions**: Reference [PRD](prd.md)
-
-### Providing Feedback
-- **Documentation Issues**: Create GitHub issue with `documentation` label
-- **Content Suggestions**: Submit pull requests with improvements
-- **Corrections**: Report inaccuracies via GitHub issues
-
-### Contact Information
-- **Documentation Owner**: [Project Maintainer]
-- **Technical Questions**: [Technical Lead]
-- **Product Questions**: [Product Manager]
-
-## Related Resources
-
-### Project Resources
-- **Main Repository**: [Project GitHub Link]
-- **Memory Bank**: [Memory Bank Documentation](../.kilocode/rules/memory-bank/)
-- **Configuration**: [Configuration Examples](../internal/config/config_template.yaml)
-- **Project Planning**: [Enhancement Roadmap](roadmap.md)
-- **Planning History**: [docs/history](history/)
-
-### External Resources
-- **MCP Protocol**: [Model Context Protocol Specification]
-- **Go Documentation**: [Official Go Documentation]
-- **Database Documentation**: [MySQL](https://dev.mysql.com/doc/), [PostgreSQL](https://www.postgresql.org/docs/), [SQLite](https://sqlite.org/docs.html)
-
-### Tools and Utilities
-- **API Testing**: [Postman](https://www.postman.com/), [Insomnia](https://insomnia.rest/)
-- **Database Clients**: [DBeaver](https://dbeaver.io/), [pgAdmin](https://www.pgadmin.org/)
-- **Documentation**: [Markdown Editor](https://markdown-editor.github.io/)
-
----
-
-**Last Updated**: December 2024  
-**Version**: 1.0.0  
-**Maintainer**: Database MCP Server Team
+Minimum files to review on MCP tool changes:
+- `README.md`
+- `docs/api-documentation.md`
+- `docs/mcp-openapi.yaml`
+- `docs/implementation-status.md`
+- `.kilocode/rules/memory-bank/*.md`

--- a/docs/analyze-schema-design.md
+++ b/docs/analyze-schema-design.md
@@ -23,7 +23,7 @@
 The `analyze-schema` MCP tool provides comprehensive database schema analysis specifically designed to help AI Large Language Models (LLMs) understand databases for better query construction, data exploration, and intelligent database interactions.
 
 ### Key Innovation
-Unlike traditional schema introspection tools, `analyze-schema` orchestrates all 12 existing MCP tools to create a unified, AI-optimized understanding of database structure, relationships, and business context.
+Unlike traditional schema introspection tools, `analyze-schema` orchestrates the core discovery and analysis MCP tools to create a unified, AI-optimized understanding of database structure, relationships, and business context.
 
 ### Core Value Proposition
 - **AI-First Design**: Output format optimized for LLM consumption and reasoning
@@ -37,7 +37,7 @@ Unlike traditional schema introspection tools, `analyze-schema` orchestrates all
 ## Tool Orchestration Architecture
 
 ### Unified Tool Integration
-The `analyze-schema` tool leverages ALL 11 existing MCP tools:
+The `analyze-schema` tool leverages key MCP tools for schema, relationship, sampling, and query guidance workflows:
 
 ```mermaid
 graph TD

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -2,1521 +2,165 @@
 
 ## Overview
 
-The Database MCP Server provides a comprehensive set of MCP (Model Context Protocol) actions for interacting with SQL databases. This document describes the complete API specification for all available tools.
+This document describes the current runtime MCP tool contracts for Database MCP Server.
 
-## Protocol Specification
+Canonical sources:
+1. `internal/mcp/server.go` (runtime registration)
+2. `docs/mcp-openapi.yaml` (machine-readable schema)
 
-### Communication Protocol
-- **Transport**: Stdio (standard input/output)
-- **Protocol**: JSON-RPC 2.0 over MCP
-- **Encoding**: UTF-8
-- **Format**: JSON
+## Protocol
 
-### Request Format
+- Protocol: MCP (JSON-RPC over stdio)
+- Primary transport: stdio
+- Optional transport: HTTP/SSE when `MCP_SSE_ADDR` is configured
+
+## Request/Response Shape
+
+Typical request:
+
 ```json
 {
   "jsonrpc": "2.0",
-  "method": "tool_name",
-  "params": {
-    "parameter1": "value1",
-    "parameter2": "value2"
-  },
-  "id": "request_id"
+  "method": "tool-name",
+  "params": {"...": "..."},
+  "id": "req_001"
 }
 ```
 
-### Response Format
+Typical success response:
+
 ```json
 {
   "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "data": {...}
-  },
-  "id": "request_id"
+  "result": {"...": "..."},
+  "id": "req_001"
 }
 ```
 
-### Error Response Format
+Typical error response:
+
 ```json
 {
   "jsonrpc": "2.0",
   "error": {
     "code": "ERROR_CODE",
-    "message": "Human-readable error message",
-    "details": {
-      "additional": "context"
-    },
-    "suggestions": [
-      "Suggestion 1",
-      "Suggestion 2"
-    ]
+    "message": "Human-readable message",
+    "details": {"...": "..."},
+    "suggestions": ["...", "..."]
   },
-  "id": "request_id"
+  "id": "req_001"
 }
 ```
 
-## MCP Tools Reference
+## Tool Catalog (Current)
 
-### 1. configure-profile
+### Profile and Connectivity
 
-Create or update a database connection profile.
+1. `configure-profile`
+- Purpose: create or update a DB connection profile
+- Key params: `profile_name`, `db_type`, `database_name`, `readonly`, plus host/port/user/pass for non-sqlite
 
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "db_type": "string (required)",
-  "host": "string (required)",
-  "port": "integer (required)",
-  "username": "string (required)",
-  "password": "string (required)",
-  "database_name": "string (required)",
-  "readonly": "boolean (optional, default: false)"
-}
-```
+2. `list-profiles`
+- Purpose: list configured profiles
+- Key params: none
 
-#### Parameter Details
-- **profile_name**: Unique identifier for the profile
-- **db_type**: Database type - one of: `mysql`, `postgresql`, `sqlite`
-- **host**: Database server hostname or IP address
-- **port**: Database server port number
-- **username**: Database username
-- **password**: Database password (will be encrypted)
-- **database_name**: Default database name
-- **readonly**: Whether to restrict operations to read-only
+3. `mcp-info`
+- Purpose: return provider version/author metadata
+- Key params: none
 
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "configure-profile",
-  "params": {
-    "profile_name": "production_db",
-    "db_type": "postgresql",
-    "host": "localhost",
-    "port": 5432,
-    "username": "app_user",
-    "password": "secure_password",
-    "database_name": "myapp",
-    "readonly": false
-  },
-  "id": "config_001"
-}
-```
+4. `list-tools`
+- Purpose: list runtime-registered tools and descriptions
+- Key params: none
 
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "message": "Profile 'production_db' configured successfully"
-  },
-  "id": "config_001"
-}
-```
+### Database Discovery and Execution
 
-#### Error Responses
-- `MISSING_PARAMETER`: Required parameter not provided
-- `INVALID_DB_TYPE`: Unsupported database type
-- `CONNECTION_FAILED`: Cannot connect to database with provided credentials
+5. `list-databases`
+- Purpose: list accessible databases/schemas for a profile
+- Key params: `profile_name`
 
----
+6. `list-tables`
+- Purpose: list tables/views in a specific database
+- Key params: `profile_name`, `database_name`
 
-### 2. list-profiles
+7. `describe-table`
+- Purpose: return comprehensive table schema metadata
+- Key params: `profile_name`, `database_name`, `table_name`
 
-List all configured database profiles.
+8. `sample-data`
+- Purpose: fetch sample rows for schema/value understanding
+- Key params: `profile_name`, `database_name`, `table_name`, optional `sample_size`
 
-#### Parameters
-None
+9. `execute-sql`
+- Purpose: execute SQL statement/query
+- Key params: `profile_name`, `database_name`, `sql`, optional `params`
 
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "list-profiles",
-  "params": {},
-  "id": "list_001"
-}
-```
+10. `discover-joins`
+- Purpose: detect joinable FK relationships and suggest joins
+- Key params: `profile_name`, optional `tables`
 
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "profiles": [
-      {
-        "profile_name": "production_db",
-        "db_type": "postgresql"
-      },
-      {
-        "profile_name": "analytics_db",
-        "db_type": "mysql"
-      }
-    ]
-  },
-  "id": "list_001"
-}
-```
+### Intelligence and Analysis
 
----
+11. `analyze-schema`
+- Purpose: multi-level schema analysis with optional advanced profiling
+- Key params: `profile_name`, `analysis_level` (`basic|detailed|comprehensive`), optional filters and `profiling`
 
-### 3. delete-profile
+12. `smart-query-builder`
+- Purpose: generate SQL from natural-language intent
+- Key params: `profile_name`, `intent`, optional `database_name`, `table_names`
 
-Delete a database connection profile.
+13. `validate-query`
+- Purpose: validate syntax/risky patterns without execution
+- Key params: `profile_name`, `sql`, optional `database_name`, `params`
 
-#### Parameters
-```json
-{
-  "profile_name": "string (required)"
-}
-```
+14. `optimize-query`
+- Purpose: run explain-style optimization analysis
+- Key params: `profile_name`, `database_name`, `sql`, optional `params`
 
-Notes:
-- `params` are positional values for prepared statements. BLOB/BINARY values must be base64-encoded strings.
+15. `analyze-data-lineage`
+- Purpose: trace upstream/downstream table dependencies
+- Key params: `profile_name`, `table_name`, optional `database_name`, `scope`
 
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "delete-profile",
-  "params": {
-    "profile_name": "old_profile"
-  },
-  "id": "delete_001"
-}
-```
+16. `discover-insights`
+- Purpose: discover KPI/trend/anomaly/distribution insights from table data
+- Key params: `profile_name`, `table_name`, optional `columns`, `insight_types`, `max_results`
 
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "message": "Profile 'old_profile' deleted successfully"
-  },
-  "id": "delete_001"
-}
-```
+17. `track-schema-changes`
+- Purpose: schema snapshot/history/migration/drift workflows
+- Key params: `profile_name`, optional `operation`, `database_name`, snapshot and migration parameters
 
-#### Error Responses
-- `PROFILE_NOT_FOUND`: Specified profile does not exist
+18. `federated-query`
+- Purpose: read-only multi-profile query federation with join/aggregation
+- Key params: either federated `sql` or `sub_queries`, optional `joins`, `aggregations`, pagination and concurrency
 
----
+## End-to-End Usage Patterns
 
-### 4. update-profile
+### Safe SQL flow
+1. `smart-query-builder`
+2. `validate-query`
+3. `optimize-query`
+4. `execute-sql`
 
-Update an existing database profile.
+### Unknown database onboarding
+1. `list-databases`
+2. `list-tables`
+3. `describe-table`
+4. `sample-data`
 
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "host": "string (optional)",
-  "port": "integer (optional)",
-  "username": "string (optional)",
-  "password": "string (optional)",
-  "database_name": "string (optional)",
-  "readonly": "boolean (optional)"
-}
-```
+### Schema governance
+1. `track-schema-changes` (`track`)
+2. `track-schema-changes` (`history`)
+3. `track-schema-changes` (`detect_drift`)
+4. `track-schema-changes` (`generate_migration`)
 
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "update-profile",
-  "params": {
-    "profile_name": "production_db",
-    "readonly": true
-  },
-  "id": "update_001"
-}
-```
+### Cross-database analytics
+1. Ensure each source has a configured profile
+2. Use `federated-query`
+3. Review metadata for partial failures/errors
 
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "message": "Profile 'production_db' updated successfully"
-  },
-  "id": "update_001"
-}
-```
+## Parameter and Schema Reference
 
----
+For full request/response schema details, use:
+- `docs/mcp-openapi.yaml`
+- `docs/mcp-examples.md`
 
-### 5. execute-sql
-
-Execute SQL queries on a database profile.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "database_name": "string (required)",
-  "sql": "string (required)",
-  "params": ["string|number|boolean|null", "... optional"]
-}
-```
-
-#### Parameter Details
-- **profile_name**: Name of the profile to use
-- **database_name**: Target database/schema (required)
-- **sql**: SQL query to execute
-- **params**: Optional positional parameters for prepared statements. BLOB/BINARY values must be base64-encoded strings.
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "execute-sql",
-  "params": {
-    "profile_name": "production_db",
-    "database_name": "production_db",
-    "sql": "SELECT id, name, email FROM users WHERE active = true LIMIT 10"
-  },
-  "id": "query_001"
-}
-```
-
-#### Success Response (SELECT Query)
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "columns": ["id", "name", "email"],
-    "rows": [
-      [1, "John Doe", "john@example.com"],
-      [2, "Jane Smith", "jane@example.com"]
-    ],
-    "row_count": 2,
-    "execution_time_ms": 45
-  },
-  "id": "query_001"
-}
-```
-
-#### Success Response (INSERT/UPDATE/DELETE)
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "rows_affected": 1,
-    "execution_time_ms": 23
-  },
-  "id": "query_001"
-}
-```
-
-#### Error Responses
-- `PROFILE_NOT_FOUND`: Specified profile does not exist
-- `SQL_SYNTAX_ERROR`: Invalid SQL syntax
-- `PERMISSION_DENIED`: Insufficient database permissions
-- `READONLY_VIOLATION`: Write operation on read-only profile
-- `CONNECTION_FAILED`: Database connection failed
-
----
-
-### 6. list-tables
-
-List all tables and views in a database.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "database_name": "string (optional)"
-}
-```
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "list-tables",
-  "params": {
-    "profile_name": "production_db"
-  },
-  "id": "tables_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "tables": [
-      {
-        "name": "users",
-        "type": "TABLE",
-        "row_count": 1250,
-        "size_bytes": 2048576
-      },
-      {
-        "name": "user_profiles",
-        "type": "VIEW",
-        "row_count": 1250,
-        "size_bytes": 0
-      }
-    ],
-    "total_count": 2
-  },
-  "id": "tables_001"
-}
-```
-
----
-
-### 7. list-databases
-
-List all databases/schemas available on the server.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)"
-}
-```
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "list-databases",
-  "params": {
-    "profile_name": "production_db"
-  },
-  "id": "databases_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "databases": [
-      {
-        "name": "myapp",
-        "owner": "app_user",
-        "size_bytes": 104857600
-      },
-      {
-        "name": "analytics",
-        "owner": "analytics_user",
-        "size_bytes": 52428800
-      }
-    ],
-    "total_count": 2
-  },
-  "id": "databases_001"
-}
-```
-
----
-
-### 8. describe-table
-
-Get detailed schema information for a specific table.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "table_name": "string (required)",
-  "database_name": "string (optional)"
-}
-```
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "describe-table",
-  "params": {
-    "profile_name": "production_db",
-    "table_name": "users"
-  },
-  "id": "describe_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "table_name": "users",
-    "table_type": "TABLE",
-    "columns": [
-      {
-        "name": "id",
-        "type": "integer",
-        "nullable": false,
-        "key": "PRI",
-        "default": null,
-        "extra": "auto_increment",
-        "max_length": null,
-        "precision": 10,
-        "scale": 0,
-        "comment": "Primary key"
-      },
-      {
-        "name": "email",
-        "type": "varchar",
-        "nullable": false,
-        "key": "UNI",
-        "default": null,
-        "extra": "",
-        "max_length": 255,
-        "precision": null,
-        "scale": 0,
-        "comment": "User email address"
-      }
-    ],
-    "indexes": [
-      {
-        "name": "PRIMARY",
-        "columns": ["id"],
-        "type": "PRIMARY",
-        "unique": true
-      },
-      {
-        "name": "idx_email",
-        "columns": ["email"],
-        "type": "UNIQUE",
-        "unique": true
-      }
-    ]
-  },
-  "id": "describe_001"
-}
-```
-
----
-
-### 9. analyze-schema
-
-Perform comprehensive schema analysis with business context inference.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "database_name": "string (optional)",
-  "level": "string (optional, default: 'DETAILED')",
-  "table_names": "array (optional)"
-}
-```
-
-#### Parameter Details
-- **level**: Analysis level - one of: `BASIC`, `DETAILED`, `COMPREHENSIVE`
-- **table_names**: Specific tables to analyze (analyzes all if not provided)
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "analyze-schema",
-  "params": {
-    "profile_name": "production_db",
-    "level": "COMPREHENSIVE",
-    "table_names": ["users", "orders", "products"]
-  },
-  "id": "analyze_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "level": "COMPREHENSIVE",
-    "database_name": "myapp",
-    "analysis_timestamp": "2024-12-09T15:12:36Z",
-    "tables_analyzed": 3,
-    "business_context": {
-      "domain": "ecommerce",
-      "entity_types": ["users", "orders", "products"],
-      "data_patterns": ["user_management", "order_processing", "inventory"]
-    },
-    "data_quality": {
-      "completeness_score": 0.95,
-      "consistency_score": 0.88,
-      "validity_score": 0.92,
-      "issues": [
-        {
-          "table": "orders",
-          "column": "customer_email",
-          "issue": "null_values",
-          "percentage": 5.2
-        }
-      ]
-    },
-    "relationships": [
-      {
-        "from_table": "orders",
-        "from_column": "user_id",
-        "to_table": "users",
-        "to_column": "id",
-        "relationship_type": "foreign_key",
-        "confidence": 0.95
-      }
-    ],
-    "query_suggestions": [
-      {
-        "description": "Find customers with recent orders",
-        "sql": "SELECT u.*, COUNT(o.id) as order_count FROM users u JOIN orders o ON u.id = o.user_id WHERE o.created_at > NOW() - INTERVAL '30 days' GROUP BY u.id",
-        "complexity": "medium"
-      }
-    ]
-  },
-  "id": "analyze_001"
-}
-```
-
----
-
-### 10. optimize-query
-
-Run EXPLAIN for a statement, apply optimization rules, and return a performance estimate.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "database_name": "string (required)",
-  "sql": "string (required)",
-  "params": ["string|number|boolean|null", "... optional"]
-}
-```
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "optimize-query",
-  "params": {
-    "profile_name": "analytics_db",
-    "database_name": "analytics_db",
-    "sql": "SELECT * FROM orders WHERE customer_id = ?",
-    "params": [123]
-  },
-  "id": "optimize_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "plan": { "...": "normalized plan" },
-    "findings": [
-      {
-        "rule": "missing_index",
-        "severity": "warn",
-        "message": "Full table scan with filter detected; an index may be missing.",
-        "suggestion": "Add an index on the columns used in the filter for table orders"
-      }
-    ],
-    "estimation": {
-      "baseline_cost": 12.3,
-      "baseline_rows": 1200,
-      "confidence": 0.75,
-      "improvement": {
-        "lower_percent": 25,
-        "upper_percent": 60,
-        "confidence": 0.7,
-        "explanation": "Indexing filter/join columns typically yields large gains."
-      },
-      "suggestions": [
-        "Add an index on the columns used in the filter for table orders"
-      ]
-    },
-    "summary": "Potential improvement: 25-60% (confidence 70%). Findings: 1."
-  },
-  "id": "optimize_001"
-}
-```
-
-#### Error Responses
-- Missing required parameters
-- Profile not found
-- Database connection/driver errors
-
----
-
-### 11. sample-data
-
-Fetch sample rows from a table for data inference.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "table_name": "string (required)",
-  "limit": "integer (optional, default: 10)",
-  "database_name": "string (optional)"
-}
-```
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "sample-data",
-  "params": {
-    "profile_name": "production_db",
-    "table_name": "users",
-    "limit": 5
-  },
-  "id": "sample_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "table_name": "users",
-    "columns": ["id", "name", "email", "created_at"],
-    "rows": [
-      [1, "John Doe", "john@example.com", "2024-01-15T10:30:00Z"],
-      [2, "Jane Smith", "jane@example.com", "2024-01-16T14:22:00Z"],
-      [3, "Bob Johnson", "bob@example.com", "2024-01-17T09:15:00Z"]
-    ],
-    "row_count": 3,
-    "limit_used": 5,
-    "total_rows": 1250,
-    "data_inference": {
-      "id": {"type": "integer", "pattern": "sequential"},
-      "name": {"type": "string", "pattern": "full_name"},
-      "email": {"type": "email", "pattern": "standard"},
-      "created_at": {"type": "timestamp", "pattern": "iso8601"}
-    }
-  },
-  "id": "sample_001"
-}
-```
-
----
-
-### 12. discover-joins
-
-Discover foreign key relationships and suggest JOIN operations.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "tables": "array (optional)",
-  "database_name": "string (optional)"
-}
-```
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "discover-joins",
-  "params": {
-    "profile_name": "production_db",
-    "tables": ["users", "orders", "products"]
-  },
-  "id": "joins_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "relationships": [
-      {
-        "from_table": "orders",
-        "from_column": "user_id",
-        "to_table": "users",
-        "to_column": "id",
-        "relationship_type": "foreign_key",
-        "confidence": 1.0,
-        "join_suggestion": "JOIN users ON orders.user_id = users.id"
-      },
-      {
-        "from_table": "orders",
-        "from_column": "product_id",
-        "to_table": "products",
-        "to_column": "id",
-        "relationship_type": "foreign_key",
-        "confidence": 1.0,
-        "join_suggestion": "JOIN products ON orders.product_id = products.id"
-      }
-    ],
-    "complex_relationships": [
-      {
-        "description": "Many-to-many relationship between users and products through orders",
-        "path": "users -> orders -> products",
-        "suggested_query": "SELECT u.name, p.name, COUNT(o.id) as order_count FROM users u JOIN orders o ON u.id = o.user_id JOIN products p ON o.product_id = p.id GROUP BY u.id, p.id"
-      }
-    ],
-    "tables_analyzed": 3
-  },
-  "id": "joins_001"
-}
-```
-
----
-
-### 13. smart-query-builder
-
-Generate SQL from natural language intent.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "intent": "string (required)",
-  "database_name": "string (optional)",
-  "table_names": "array (optional)"
-}
-```
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "smart-query-builder",
-  "params": {
-    "profile_name": "production_db",
-    "intent": "Find customers who placed orders in the last 30 days with total order value over $100"
-  },
-  "id": "smart_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "intent": "Find customers who placed orders in the last 30 days with total order value over $100",
-    "generated_sql": "SELECT u.id, u.name, u.email, SUM(o.total_amount) as total_spent FROM users u JOIN orders o ON u.id = o.user_id WHERE o.created_at >= NOW() - INTERVAL '30 days' GROUP BY u.id, u.name, u.email HAVING SUM(o.total_amount) > 100 ORDER BY total_spent DESC",
-    "explanation": "This query joins users with their orders, filters for recent orders within the last 30 days, calculates total spending per customer, and returns customers who have spent more than $100.",
-    "tables_used": ["users", "orders"],
-    "complexity": "medium",
-    "estimated_rows": 150,
-    "optimization_suggestions": [
-      "Consider adding an index on orders.created_at for better performance",
-      "Consider adding an index on orders.user_id for faster joins"
-    ]
-  },
-  "id": "smart_001"
-}
-```
-
----
-
-### 14. list-tools
-
-List all available MCP tools with their specifications.
-
-#### Parameters
-None
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "list-tools",
-  "params": {},
-  "id": "tools_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "tools": [
-      {
-        "name": "configure-profile",
-        "description": "Create or update a database connection profile",
-        "parameters": {
-          "type": "object",
-          "properties": {
-            "profile_name": {"type": "string"},
-            "db_type": {"type": "string", "enum": ["mysql", "postgresql", "sqlite"]},
-            "host": {"type": "string"},
-            "port": {"type": "integer"},
-            "username": {"type": "string"},
-            "password": {"type": "string"},
-            "database_name": {"type": "string"},
-            "readonly": {"type": "boolean"}
-          },
-          "required": ["profile_name", "db_type", "host", "port", "username", "password", "database_name"]
-        }
-      },
-      {
-        "name": "execute-sql",
-        "description": "Execute SQL queries on a database profile",
-        "parameters": {
-          "type": "object",
-          "properties": {
-            "profile_name": {"type": "string"},
-            "sql_query": {"type": "string"},
-            "database_name": {"type": "string"}
-          },
-          "required": ["profile_name", "sql_query"]
-        }
-      }
-    ],
-    "total_count": 15
-  },
-  "id": "tools_001"
-}
-```
-
----
-
-### 15. mcp-info
-
-Get MCP server information and capabilities.
-
-#### Parameters
-None
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "mcp-info",
-  "params": {},
-  "id": "info_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "server": {
-      "name": "Database MCP Server",
-      "version": "1.0.0",
-      "description": "Unified database access via Model Context Protocol",
-      "author": "guyinwonder"
-    },
-    "capabilities": {
-      "supported_databases": ["mysql", "mariadb", "postgresql", "sqlite"],
-      "features": [
-        "connection_pooling",
-        "encrypted_credentials",
-        "read_only_mode",
-        "schema_analysis",
-        "query_building",
-        "join_discovery"
-      ],
-      "protocol_version": "1.0.0",
-      "transport": "stdio"
-    },
-    "configuration": {
-      "max_pool_size": 25,
-      "log_level": "info",
-      "encryption_enabled": true
-    }
-  },
-  "id": "info_001"
-}
-```
-
-## Error Codes Reference
-
-### Connection Errors
-- `CONNECTION_FAILED`: Cannot establish database connection
-- `TIMEOUT`: Query execution timeout
-- `RESOURCE_EXHAUSTED`: Connection pool exhausted
-
-### Configuration Errors
-- `PROFILE_NOT_FOUND`: Specified profile does not exist
-- `CONFIG_NOT_FOUND`: Configuration file missing
-- `INVALID_CONFIGURATION`: Malformed configuration
-
-### SQL Errors
-- `SQL_SYNTAX_ERROR`: Invalid SQL syntax
-- `TABLE_NOT_FOUND`: Table does not exist
-- `COLUMN_NOT_FOUND`: Column does not exist
-- `PERMISSION_DENIED`: Insufficient database permissions
-- `READONLY_VIOLATION`: Write operation on read-only profile
-- `CONSTRAINT_VIOLATION`: Database constraint violation
-- `DATA_TYPE_MISMATCH`: Data type conflict
-
-### Parameter Errors
-- `MISSING_PARAMETER`: Required parameter not provided
-- `INVALID_PARAMETER`: Parameter value invalid
-- `UNSUPPORTED_DATABASE`: Database type not supported
-
-### System Errors
-- `INTERNAL_ERROR`: Unexpected internal error
-- `ENCRYPTION_ERROR`: Credential encryption/decryption failed
-
-## Usage Examples
-
-### Complete Workflow Example
-
-```bash
-# 1. Configure a new profile
-echo '{
-  "jsonrpc": "2.0",
-  "method": "configure-profile",
-  "params": {
-    "profile_name": "mydb",
-    "db_type": "postgresql",
-    "host": "localhost",
-    "port": 5432,
-    "username": "user",
-    "password": "pass",
-    "database_name": "app"
-  },
-  "id": "1"
-}' | ./mcp-server
-
-# 2. List tables
-echo '{
-  "jsonrpc": "2.0",
-  "method": "list-tables",
-  "params": {"profile_name": "mydb"},
-  "id": "2"
-}' | ./mcp-server
-
-# 3. Execute query
-echo '{
-  "jsonrpc": "2.0",
-  "method": "execute-sql",
-  "params": {
-    "profile_name": "mydb",
-    "sql_query": "SELECT COUNT(*) FROM users"
-  },
-  "id": "3"
-}' | ./mcp-server
-```
-
-### Integration with Kilocode AI
-
-```yaml
-mcp_providers:
-  - name: database-mcp
-    type: process
-    command: /path/to/mcp-server
-    working_dir: /path/to/config
-    auto_start: true
-```
-
-## Performance Considerations
-
-### Connection Pooling
-- Default pool size: 25 connections
-- Idle connections: 12 (half of max)
-- Connection lifetime: 1 hour
-- Idle timeout: 30 minutes
-
-### Query Optimization
-- Use LIMIT clauses for large result sets
-- Consider using sample-data for data exploration
-- Leverage analyze-schema for query optimization
-- Use appropriate indexes for frequent queries
-
-### Memory Usage
-- Large result sets are streamed to reduce memory usage
-- Connection pooling limits memory consumption
-- Automatic garbage collection optimization
-
-## Security Notes
-
-### Credential Protection
-- All passwords encrypted with AES-256-GCM
-- 32-character encryption key required
-- Keys stored in environment variables recommended
-- No plaintext credentials in logs or memory
-
-### Access Control
-- Read-only profiles prevent write operations
-- SQL injection prevention via parameterized queries
-- Database-level permissions enforced
-- Connection-level access control
-
-## Troubleshooting
-
-### Common Issues
-
-#### Connection Failures
-1. Verify database server is running
-2. Check network connectivity
-3. Validate credentials
-4. Confirm database exists
-
-#### Permission Errors
-1. Check database user permissions
-2. Verify read-only profile settings
-3. Ensure database access rights
-
-#### Performance Issues
-1. Monitor connection pool usage
-2. Check query execution times
-3. Review database indexes
-4. Consider query optimization
-
-### Debug Information
-
-Enable verbose logging for debugging:
-```bash
-./mcp-server --verbose
-```
-
-Check server information:
-```bash
-echo '{"method":"mcp-info"}' | ./mcp-server
-```
-
-## Future MCP Tools (Planned Enhancements)
-
-### 16. validate-query
-
-Validate SQL syntax, logic, and basic security patterns without execution.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "database_name": "string (optional)",
-  "sql": "string (required)",
-  "params": ["string|number|boolean|null", "... optional"]
-}
-```
-
-#### Parameter Details
-- **profile_name**: Name of the profile to use for validation
-- **database_name**: Override default database (optional)
-- **sql**: SQL query to validate (not executed)
-- **params**: Optional parameters for context (not executed). BLOB/BINARY values must be base64-encoded strings.
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "validate-query",
-  "params": {
-    "profile_name": "production_db",
-    "sql": "SELECT * FROM users WHERE name = 'John' AND email = 'john@example.com'"
-  },
-  "id": "validate_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "is_valid": false,
-    "issues": [
-      {
-        "rule": "syntax_error",
-        "severity": "error",
-        "message": "SQL syntax error: syntax error at position 63 near '\"'",
-        "suggestion": "Review SQL syntax; ensure keywords and clauses are spelled correctly."
-      },
-      {
-        "rule": "tautology",
-        "severity": "warn",
-        "message": "Potential tautology detected (OR 1=1).",
-        "suggestion": "Use parameterized queries; avoid concatenating untrusted input."
-      }
-    ],
-    "summary": "Validation failed.",
-    "sql": "SELECT * FROM users WHERE name = 'John' AND email = 'john@example.com'",
-    "profile_name": "production_db"
-  },
-  "id": "validate_001"
-}
-```
-
-#### Error Responses
-- Missing required parameters
-- Profile not found
-
----
-
-### 17. analyze-data-lineage
-
-Trace data dependencies and impact relationships across the database ecosystem.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "table_name": "string (required)",
-  "analysis_scope": "string (optional, default: 'both')",
-  "database_name": "string (optional)"
-}
-```
-
-#### Parameter Details
-- **profile_name**: Name of the profile to use for lineage analysis
-- **table_name**: Target table for dependency analysis
-- **analysis_scope**: Scope of analysis - one of: `upstream`, `downstream`, `both`
-- **database_name**: Override default database
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "analyze-data-lineage",
-  "params": {
-    "profile_name": "production_db",
-    "table_name": "orders",
-    "analysis_scope": "both"
-  },
-  "id": "lineage_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "target_table": "orders",
-    "analysis_scope": "both",
-    "data_flow": {
-      "upstream": [
-        {
-          "table": "customers",
-          "relationship": "foreign_key",
-          "columns": ["customer_id"],
-          "impact_level": "High"
-        }
-      ],
-      "downstream": [
-        {
-          "table": "order_items",
-          "relationship": "foreign_key",
-          "columns": ["order_id"],
-          "impact_level": "Medium"
-        }
-      ]
-    },
-    "impact_analysis": {
-      "change_impact": "High",
-      "affected_tables": ["customers", "orders", "order_items", "inventory"],
-      "critical_dependencies": ["customers.id", "products.id"],
-      "change_propagation_time": "2-5 minutes"
-    },
-    "dependency_graph": {
-      "nodes": ["customers", "orders", "order_items", "products", "inventory"],
-      "edges": [
-        {"from": "customers", "to": "orders", "type": "foreign_key"},
-        {"from": "orders", "to": "order_items", "type": "foreign_key"},
-        {"from": "products", "to": "order_items", "type": "foreign_key"}
-      ]
-    }
-  },
-  "id": "lineage_001"
-}
-```
-
-#### Error Responses
-- `TABLE_NOT_FOUND`: Specified table does not exist
-- `LINEAGE_TOO_COMPLEX`: Dependency graph too complex to analyze
-
----
-
-### 18. discover-insights
-
-Automatically discover business insights, KPIs, trends, and anomalies from database data.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "table_names": "array (optional)",
-  "analysis_type": "string (required)",
-  "database_name": "string (optional)"
-}
-```
-
-#### Parameter Details
-- **profile_name**: Name of the profile to use for insight discovery
-- **table_names**: Specific tables to analyze (analyzes all if not provided)
-- **analysis_type**: Type of analysis - one of: `kpi`, `trends`, `anomalies`, `correlations`
-- **database_name**: Override default database
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "discover-insights",
-  "params": {
-    "profile_name": "production_db",
-    "table_names": ["orders", "customers"],
-    "analysis_type": "kpi"
-  },
-  "id": "insights_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "status": "success",
-    "analysis_type": "kpi",
-    "insights": [
-      {
-        "type": "kpi",
-        "title": "Monthly Revenue Growth",
-        "description": "Revenue has increased by 23% month-over-month with strong correlation to customer acquisition",
-        "supporting_data": {
-          "current_month": "$125,430",
-          "previous_month": "$101,950",
-          "growth_rate": "23.0%",
-          "correlation_coefficient": 0.87
-        },
-        "visualization_suggestion": "line_chart",
-        "business_impact": "High",
-        "confidence": 0.92
-      },
-      {
-        "type": "kpi",
-        "title": "Customer Retention Rate",
-        "description": "85% of customers make repeat purchases within 30 days, indicating strong loyalty",
-        "supporting_data": {
-          "retention_rate": "85%",
-          "industry_average": "65%",
-          "improvement": "+20 percentage points"
-        },
-        "visualization_suggestion": "gauge_chart",
-        "business_impact": "Medium",
-        "confidence": 0.88
-      }
-    ]
-  },
-  "id": "insights_001"
-}
-```
-
-#### Error Responses
-- `INSUFFICIENT_DATA`: Not enough data for reliable analysis
-- `ANALYSIS_FAILED`: Insight discovery process failed
-
----
-
-### 19. track-schema-changes
-
-Track and analyze schema evolution over time with automated migration assistance.
-
-#### Parameters
-```json
-{
-  "profile_name": "string (required)",
-  "operation": "string (optional, default: 'track')",
-  "database_name": "string (optional)",
-  "dialect": "string (optional)",
-  "from_snapshot_id": "string (optional, required with to_snapshot_id for migration)",
-  "to_snapshot_id": "string (optional, required with from_snapshot_id for migration)",
-  "snapshot_id": "string (optional, baseline for drift)",
-  "limit": "integer (optional, history only)",
-  "retention_days": "integer (optional, track only)"
-}
-```
-
-#### Parameter Details
-- **profile_name**: Name of the profile to use for schema tracking
-- **operation**: One of `track`, `history`, `generate_migration`, `detect_drift`
-- **database_name**: Override default database
-- **dialect**: SQL dialect for migration generation (`mysql`, `postgresql`, `sqlite`)
-- **from_snapshot_id / to_snapshot_id**: Explicit snapshot pair for migration generation
-- **snapshot_id**: Baseline snapshot ID for drift detection (defaults to latest)
-- **limit**: Number of history snapshots to return
-- **retention_days**: Snapshot retention window in days (default 30)
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "track-schema-changes",
-  "params": {
-    "profile_name": "production_db",
-    "operation": "track",
-    "retention_days": 30
-  },
-  "id": "schema_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "operation": "track",
-    "profile_name": "production_db",
-    "snapshot_id": "snap-1738863700123456789",
-    "previous_snapshot_id": "snap-1738863600123456789",
-    "changes": [
-      {
-        "type": "add_column",
-        "table": "users",
-        "column": "email",
-        "impact": "compatible"
-      }
-    ],
-    "migration": {
-      "from_version": "snap-1738863600123456789",
-      "to_version": "snap-1738863700123456789",
-      "dialect": "sqlite",
-      "statements": [
-        "ALTER TABLE \"users\" ADD COLUMN \"email\" TEXT;"
-      ],
-      "estimated_time": "about 2 minute(s)",
-      "is_reversible": true
-    },
-    "summary": "Schema changes tracked: 1 change(s) detected"
-  },
-  "id": "schema_001"
-}
-```
-
-#### Error Responses
-- `MISSING_PARAMETER`: `profile_name` is required
-- `INVALID_INPUT`: Invalid operation or invalid snapshot arguments
-- `PROFILE_NOT_FOUND`: Profile does not exist
-
----
-
-### 20. federated-query
-
-Execute read-only queries across multiple database profiles with optional cross-profile JOINs and aggregations.
-
-#### Parameters
-```json
-{
-  "sql": "string (optional, profile.table syntax)",
-  "sub_queries": "array (optional if sql provided)",
-  "joins": "array (optional)",
-  "aggregations": "array (optional)",
-  "limit": "integer (optional)",
-  "offset": "integer (optional)",
-  "max_concurrency": "integer (optional)"
-}
-```
-
-#### Parameter Details
-- **sql**: Optional federated SQL expression containing `profile.table` references
-- **sub_queries**: Explicit subquery list (`profile`, `sql`, `alias`) when not using `sql` parsing
-- **joins**: Join definitions (`left`, `right`, `type`) with types: `INNER`, `LEFT`, `RIGHT`, `FULL`
-- **aggregations**: Optional aggregate functions (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`)
-- **limit / offset**: Final result pagination controls
-- **max_concurrency**: Maximum number of subqueries to run in parallel
-
-#### Example Request
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "federated-query",
-  "params": {
-    "sub_queries": [
-      {"profile": "crm_db", "sql": "SELECT id, name FROM users", "alias": "u"},
-      {"profile": "analytics_db", "sql": "SELECT user_id, total FROM orders", "alias": "o"}
-    ],
-    "joins": [
-      {"left": "u.id", "right": "o.user_id", "type": "INNER"}
-    ],
-    "limit": 100,
-    "max_concurrency": 4
-  },
-  "id": "federated_001"
-}
-```
-
-#### Success Response
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "columns": ["id", "name", "user_id", "total"],
-    "rows": [[1, "Alice", 1, 100]],
-    "metadata": {
-      "execution_time_ms": 32,
-      "rows_from_each": {
-        "u": 10,
-        "o": 25
-      },
-      "errors": [
-        {"profile": "archive_db", "alias": "a", "code": "SUBQUERY_EXECUTION_FAILED", "message": "connection timeout"}
-      ]
-    }
-  },
-  "id": "federated_001"
-}
-```
-
-#### Error Responses
-- `INVALID_INPUT`: Request shape invalid or unsupported SQL
-- `PROFILE_NOT_FOUND`: Subquery references an unknown profile
-- `SQL_EXECUTION_ERROR`: Federated execution failed
-
----
-## Version History
-
-### v1.0.0 (Current)
-- Initial release with all 15 MCP tools (optimize-query included)
-- Support for MySQL, MariaDB, PostgreSQL, SQLite
-- AES-256-GCM credential encryption
-- Connection pooling and performance optimization
-- Comprehensive error handling and logging
-
-### v1.1.0 (Planned - AI Enhancement Phase 1)
-- **Query Validation**: `validate-query` tool for syntax and logic checking
-- **Enhanced NLP**: Context-aware `smart-query-builder` with multi-turn support
-- **Performance Improvements**: Advanced execution plan analysis
-
-### v1.2.0 (Planned - AI Enhancement Phase 2)
-- **Data Lineage**: `analyze-data-lineage` tool for dependency tracking
-- **Business Intelligence**: `discover-insights` tool for KPI and trend analysis
-- **Advanced Analytics**: Statistical analysis and anomaly detection
-- **Impact Assessment**: Change impact prediction and analysis
-
-### v1.3.0 (Planned - AI Enhancement Phase 3)
-- **Schema Evolution**: `track-schema-changes` tool for change management
-- **Advanced Profiling**: Enhanced `analyze-schema` with statistical analysis
-- **Multi-DB Federation**: `federated-query` tool for cross-database operations
-- **Enterprise Features**: Advanced data quality and governance capabilities
-
-### Future Versions
-- Additional database support (SQL Server, Oracle)
-- GraphQL support
-- Advanced monitoring and metrics
+These files are the maintained detailed contract references.

--- a/docs/history/architecture-validation.md
+++ b/docs/history/architecture-validation.md
@@ -1,5 +1,8 @@
 # Database MCP Server - Architecture Validation
 
+> Historical snapshot note: this file preserves earlier planning/execution context and may not reflect the latest runtime contracts.
+
+
 ## Overview
 
 This document validates the enhancement roadmap against the existing Database MCP Server architecture to ensure compatibility, maintainability, and alignment with current design principles.

--- a/docs/history/implementation-roadmap.md
+++ b/docs/history/implementation-roadmap.md
@@ -1,5 +1,8 @@
 # Database MCP Server - Implementation Roadmap
 
+> Historical snapshot note: this file preserves earlier planning/execution context and may not reflect the latest runtime contracts.
+
+
 ## Overview
 
 This document provides a high-level overview of the Database MCP Server enhancement roadmap based on the PRD analysis recommendations. It outlines the strategic direction for transforming the current production-ready MCP server into an AI-enhanced database interaction platform.

--- a/docs/history/implementation-tasks.md
+++ b/docs/history/implementation-tasks.md
@@ -1,5 +1,8 @@
 # Database MCP Server - Detailed Implementation Tasks
 
+> Historical snapshot note: this file preserves earlier planning/execution context and may not reflect the latest runtime contracts.
+
+
 ## Overview
 
 This document provides detailed task breakdowns for each vertical slice, with specific subtasks that can be completed independently. Each task is designed to be small enough to be finished in one development session while delivering meaningful progress.

--- a/docs/history/mcp-tool-detection-fix.md
+++ b/docs/history/mcp-tool-detection-fix.md
@@ -1,5 +1,8 @@
 # MCP Tool Detection Bug Fix Plan
 
+> Historical snapshot note: this file preserves earlier planning/execution context and may not reflect the latest runtime contracts.
+
+
 ## Issue Summary
 
 The Database MCP Server has all 12 profile management and database tools implemented, but MCP clients (Codex, Kilocode) cannot detect them due to a critical bug in the MCP Go SDK v0.2.0 implementation.

--- a/docs/history/project-plan-roadmap.md
+++ b/docs/history/project-plan-roadmap.md
@@ -1,5 +1,8 @@
 # Database MCP Server - Enhancement Roadmap
 
+> Historical snapshot note: this file preserves earlier planning/execution context and may not reflect the latest runtime contracts.
+
+
 ## Executive Summary
 
 This roadmap outlines the enhancement plan for the Database MCP Server based on the PRD Analysis Report recommendations. The plan focuses on transforming the current production-ready MCP server into an AI-enhanced database interaction platform with advanced query optimization, natural language processing, and business intelligence capabilities.

--- a/docs/history/vertical-slices.md
+++ b/docs/history/vertical-slices.md
@@ -1,5 +1,8 @@
 # Database MCP Server - Vertical Slices Definition
 
+> Historical snapshot note: this file preserves earlier planning/execution context and may not reflect the latest runtime contracts.
+
+
 ## Overview
 
 This document defines the vertical slices for implementing the Database MCP Server enhancements. Each vertical slice is designed to be a complete, end-to-end implementation that delivers immediate value while building toward the comprehensive roadmap goals.

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -2,302 +2,77 @@
 
 ## Overview
 
-This document tracks the current implementation status of all features and requirements defined in the PRD. The Database MCP Server is currently in production-ready state with version v1.1.0.
+This document tracks the current implementation status of the Database MCP Server against the active codebase.
 
 ## Project Information
 
-- **Version:** v1.1.0
-- **Status:** Production Ready with F4 federation complete and GHCR package publishing enabled
-- **Author:** guyinwonder
-- **Created Using:** OpenAI GPT-4.1 via VSCode Kilocode AI code assistant extension
-- **Last Updated:** February 2026
-- **Toolchain:** Go 1.25.7 (current)
-- **Distribution:** GitHub Releases (tar/zip binaries) + GitHub Packages (GHCR container images)
+- Version: `v1.1.0`
+- Status: Production Ready
+- Author: `guyinwonder`
+- Toolchain: `go 1.25` with `go1.25.7`
+- MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.2.0`
+- Distribution:
+  - GitHub Releases (binary artifacts)
+  - GitHub Packages / GHCR (`ghcr.io/guyinwonder168/database-mcp-server`)
 
-## Core Implementation Status
+## Core Capabilities
 
-### ✅ Completed Features
+- Multi-database support: MySQL, MariaDB, PostgreSQL, SQLite
+- Secure profile-based connectivity with encrypted credentials (AES-GCM)
+- Read-only policy enforcement per profile
+- Schema introspection and analysis
+- Query generation, validation, and optimization workflows
+- Data lineage and business insight discovery
+- Schema snapshot/history/migration/drift tracking
+- Cross-profile federated read-only querying
 
-#### 1. Multi-Database Support
-- **Status:** ✅ **COMPLETED**
-- **Details:** Full support for MySQL, MariaDB, PostgreSQL, and SQLite
-- **Implementation:** Database abstraction layer with unified MCP interface
-- **Testing:** Comprehensive integration tests for all database types
+## MCP Tool Status (Runtime)
 
-#### 2. Connection Profile Management
-- **Status:** ✅ **COMPLETED**
-- **Components:**
-  - Interactive CLI setup wizard for first-time configuration
-  - `configure-profile` MCP action for programmatic profile creation/update
-  - `list-profiles` MCP action for profile enumeration
-  - `delete-profile` MCP action for profile removal
-  - `update-profile` MCP action for profile modification
-- **Security:** AES-256-GCM encryption for stored credentials
+The runtime currently registers **18 MCP tools**.
 
-#### 3. Database Interaction
-- **Status:** ✅ **COMPLETED**
-- **Components:**
-  - `execute-sql` MCP action with parameterized query support
-  - Read-only enforcement with SQL parsing level validation
-  - Cross-database query support with fully qualified table names
-  - Structured result formatting and error handling
+| Tool | Status | Notes |
+|---|---|---|
+| `configure-profile` | ✅ Implemented | Create/update connection profiles |
+| `list-profiles` | ✅ Implemented | List configured profiles |
+| `execute-sql` | ✅ Implemented | Parameterized SQL execution |
+| `list-tables` | ✅ Implemented | List tables/views in selected DB |
+| `describe-table` | ✅ Implemented | Detailed schema metadata |
+| `list-databases` | ✅ Implemented | Enumerate schemas/databases |
+| `analyze-schema` | ✅ Implemented | basic/detailed/comprehensive + optional profiling |
+| `smart-query-builder` | ✅ Implemented | Natural-language intent to SQL |
+| `optimize-query` | ✅ Implemented | EXPLAIN-based findings and estimates |
+| `validate-query` | ✅ Implemented | Syntax/risk checks without execution |
+| `analyze-data-lineage` | ✅ Implemented | Upstream/downstream dependency mapping |
+| `discover-insights` | ✅ Implemented | KPI/trend/anomaly/distribution detection |
+| `track-schema-changes` | ✅ Implemented | track/history/migration/drift operations |
+| `federated-query` | ✅ Implemented | Multi-profile read-only query federation |
+| `discover-joins` | ✅ Implemented | FK relationship and join suggestions |
+| `sample-data` | ✅ Implemented | Sample rows for value/type inference |
+| `mcp-info` | ✅ Implemented | Provider metadata/version |
+| `list-tools` | ✅ Implemented | Runtime tool discovery |
 
-#### 4. Schema Introspection
-- **Status:** ✅ **COMPLETED**
-- **Components:**
-  - `list-tables` MCP action for table/view enumeration
-  - `list-databases` MCP action for database/schema listing
-  - `describe-table` MCP action with comprehensive column metadata
-  - `analyze-schema` MCP action with multi-level analysis (BASIC/DETAILED/COMPREHENSIVE)
+## Implementation Phases
 
-#### 5. Advanced Schema Analysis
-- **Status:** ✅ **COMPLETED**
-- **Features:**
-  - Business context inference
-  - Data quality metrics
-  - Relationship discovery
-  - Smart Query Builder integration
-  - Optional advanced profiling (`profiling: true`) with column statistics, pattern detection, and quality scoring
-  - Complete type system implementation
+Roadmap slices are complete:
+- Phase 1 complete: `optimize-query`, `validate-query`, smart-query-builder enhancements
+- Phase 2 complete: `analyze-data-lineage`, `discover-insights`
+- Phase 3 complete: `track-schema-changes`, advanced `analyze-schema` profiling, `federated-query`
 
-#### 6. Data Discovery Tools
-- **Status:** ✅ **COMPLETED**
-- **Components:**
-  - `sample-data` MCP action for data format inference
-  - `discover-joins` MCP action for foreign key relationship discovery
-  - `smart-query-builder` MCP action for natural language to SQL conversion
+## Testing and Quality
 
-#### 7. Security Implementation
-- **Status:** ✅ **COMPLETED**
-- **Features:**
-  - AES-256-GCM encryption for credential storage
-  - 32-character encryption key with environment variable support
-  - Zero plaintext credential storage
-  - SQL injection prevention via parameterized queries
-  - Read-only profile enforcement
+- Unit and integration test suites are in place under `internal/mcp/*_test.go`
+- Live integration tests available for PostgreSQL and MySQL/MariaDB using `DB_MCP_IT_*` environment variables
+- CI includes linting, tests, and Sonar quality checks
 
-#### 8. Performance & Scalability
-- **Status:** ✅ **COMPLETED**
-- **Features:**
-  - Connection pooling with configurable limits (SetMaxOpenConns/SetMaxIdleConns)
-  - Stateless design for scalability
-  - Efficient resource management
-  - Performance benchmarks meeting PRD requirements
+## Operational Status
 
-#### 9. MCP Protocol Compliance
-- **Status:** ✅ **COMPLETED**
-- **Features:**
-  - Full compliance with Model Context Protocol specification
-  - Stdio transport implementation
-  - JSON-RPC protocol support
-  - `list-tools` MCP action for dynamic tool discovery
-  - `mcp-info` MCP action for server capability discovery
+- Logging: structured JSON with rotation
+- Config: auto-created `config.yaml` on first run
+- Packaging:
+  - release workflow publishes tags and release assets
+  - package workflow publishes GHCR images for tags and backfill/manual runs
 
-#### 10. Error Handling & Logging
-- **Status:** ✅ **COMPLETED**
-- **Features:**
-  - Structured JSON error responses with actionable suggestions
-  - Comprehensive error code system
-  - Structured JSON logging with file rotation (500KB limit)
-  - Multi-output logging (stdout + file)
-  - 7-day log retention
+## Current Focus
 
-#### 11. Configuration Management
-- **Status:** ✅ **COMPLETED**
-- **Features:**
-  - Human-readable YAML configuration
-  - Self-healing configuration (auto-creates config.yaml)
-  - Configuration cleanup (removed obsolete user_key/user_secret fields)
-  - Secure random AES key generation
-  - Environment variable override support
-
-#### 12. Testing & Documentation
-- **Status:** ✅ **COMPLETED**
-- **Features:**
-  - Comprehensive unit tests for all components
-  - Integration tests with real databases
-  - Complete documentation for all current MCP tools
-  - Database profile examples for all supported types
-  - Production deployment documentation
-
-## MCP Tools Implementation Status
-
-| Tool Name | Status | Description |
-|-----------|--------|-------------|
-| configure-profile | ✅ **COMPLETED** | Create/update database connection profiles |
-| list-profiles | ✅ **COMPLETED** | List all configured profiles |
-| delete-profile | ✅ **COMPLETED** | Delete a database profile |
-| update-profile | ✅ **COMPLETED** | Update existing profile settings |
-| execute-sql | ✅ **COMPLETED** | Execute SQL queries with read-only enforcement |
-| list-tables | ✅ **COMPLETED** | List tables and views |
-| list-databases | ✅ **COMPLETED** | List databases/schemas |
-| describe-table | ✅ **COMPLETED** | Get comprehensive table schema |
-| analyze-schema | ✅ **COMPLETED** | Multi-level schema analysis with business context |
-| sample-data | ✅ **COMPLETED** | Fetch sample rows for data inference |
-| discover-joins | ✅ **COMPLETED** | Discover foreign key relationships |
-| smart-query-builder | ✅ **COMPLETED** | Natural language to SQL conversion |
-| optimize-query | ✅ **COMPLETED** | EXPLAIN-based query optimization findings |
-| validate-query | ✅ **COMPLETED** | SQL validation and safety checks |
-| analyze-data-lineage | ✅ **COMPLETED** | Upstream/downstream table dependency analysis |
-| discover-insights | ✅ **COMPLETED** | KPI/trend/anomaly/distribution insight discovery |
-| track-schema-changes | ✅ **COMPLETED** | Snapshot tracking, history, migration generation, and drift detection |
-| federated-query | ✅ **COMPLETED** | Read-only cross-profile subquery execution with JOIN/aggregation support |
-| list-tools | ✅ **COMPLETED** | List all available MCP tools |
-| mcp-info | ✅ **COMPLETED** | Get server information and capabilities |
-
-**Total:** 18 MCP tools fully implemented and documented
-
-## Database Support Status
-
-| Database | Status | Driver Version | Tested Version | Features |
-|----------|--------|----------------|----------------|----------|
-| MySQL | ✅ **COMPLETED** | github.com/go-sql-driver/mysql v1.9.3 | 5.7+, 8.0+ | Full feature support |
-| MariaDB | ✅ **COMPLETED** | github.com/go-sql-driver/mysql v1.9.3 | 10.2+ | Full feature support |
-| PostgreSQL | ✅ **COMPLETED** | github.com/lib/pq v1.10.9 | 10+, 11+, 12+, 13+, 14+, 15+, 16+ | Full feature support |
-| SQLite | ✅ **COMPLETED** | github.com/mattn/go-sqlite3 v1.14.30 | 3.8.0+ | Full feature support |
-
-## Known Issues & Technical Debt
-
-### Resolved Issues
-- ✅ Duplicate tool registration in server.go - **RESOLVED**
-- ✅ Type conversion limited to MySQL only - **RESOLVED** (extended to all databases)
-- ✅ Configuration cleanup (obsolete fields) - **RESOLVED**
-
-### Current Known Issues
-- **None** - All critical issues have been resolved
-
-### Minor Technical Debt
-- Consider adding connection health checks
-- Enhanced metrics collection for monitoring
-- Optional query result caching for repeated queries
-
-## Performance Metrics
-
-### Current Performance
-- **Query Response Time:** 95% of queries complete within 3 seconds (exceeds PRD requirement of 5 seconds)
-- **Connection Setup:** New connections established within 0.5 seconds (exceeds PRD requirement of 1 second)
-- **Memory Usage:** ~256MB RAM under normal load (well under PRD requirement of 512MB)
-- **System Availability:** > 99.9% uptime in production testing
-
-### Benchmark Results
-- **Concurrent Connections:** Successfully handles 100+ simultaneous MCP actions
-- **Database Size:** Tested with databases up to 500GB without performance degradation
-- **Query Complexity:** Handles complex queries with 15+ table JOINs efficiently
-
-## Security Status
-
-### Security Implementation
-- ✅ AES-256-GCM encryption for credential storage
-- ✅ Zero plaintext credential storage
-- ✅ SQL injection prevention via parameterized queries
-- ✅ Read-only profile enforcement
-- ✅ Secure random key generation
-- ✅ Environment variable support for encryption keys
-
-### Security Audit Status
-- ✅ Code review completed
-- ✅ Dependency vulnerability scan completed
-- ✅ Security testing completed
-- ✅ Production security hardening applied
-
-## Testing Coverage
-
-### Test Status
-- **Unit Tests:** 95% code coverage
-- **Integration Tests:** Full coverage for all database types
-- **End-to-End Tests:** Complete MCP workflow testing
-- **Performance Tests:** Load testing up to 1000 concurrent operations
-- **Security Tests:** Penetration testing and vulnerability assessment
-
-### Test Automation
-- ✅ Continuous integration testing
-- ✅ Automated regression testing
-- ✅ Performance benchmarking
-- ✅ Security scanning
-
-## Documentation Status
-
-### Documentation Completeness
-- ✅ README.md with comprehensive setup and usage guide
-- ✅ All 12 MCP tools documented with examples
-- ✅ Database configuration examples for all supported types
-- ✅ API documentation with complete specifications
-- ✅ Deployment guide for production environments
-- ✅ Troubleshooting guide with common issues
-
-### Documentation Quality
-- ✅ Technical accuracy verified
-- ✅ Examples tested and validated
-- ✅ User feedback incorporated
-- ✅ Regular maintenance schedule established
-
-## Production Readiness
-
-### Deployment Status
-- ✅ Production deployment guide completed
-- ✅ Monitoring and alerting configured
-- ✅ Backup and recovery procedures documented
-- ✅ Scaling guidelines established
-- ✅ Security hardening applied
-
-### Operational Readiness
-- ✅ Logging and monitoring implemented
-- ✅ Error handling and recovery procedures
-- ✅ Performance monitoring in place
-- ✅ Security monitoring active
-
-## Enhancement Roadmap Status
-
-### PRD Analysis-Based Enhancements
-
-**Planning Phase**: ✅ **COMPLETED**
-- **PRD Analysis**: Complete - 8 enhancement gaps identified
-- **Roadmap Development**: Complete - 3-phase implementation plan
-- **Vertical Slices**: Complete - 8 vertical slices defined
-- **Task Breakdown**: Complete - Detailed subtasks for each slice
-- **Documentation Updates**: In Progress
-
-**Implementation Status**: ✅ **COMPLETED (Current Planned Slices)**
-
-### Phase 1: Foundation Intelligence (COMPLETED)
-- **Slice 1.1**: Query Optimization Insights - `optimize-query` MCP tool - ✅ **COMPLETED**
-- **Slice 1.2**: Query Validation Framework - `validate-query` MCP tool - ✅ **COMPLETED**
-- **Slice 1.3**: Enhanced Natural Language Processing - Context-aware `smart-query-builder` - ✅ **COMPLETED**
-
-### Phase 2: Business Intelligence Layer (Completed)
-- **Slice 2.1**: Data Lineage and Impact Analysis - `analyze-data-lineage` MCP tool - ✅ **COMPLETED**
-- **Slice 2.2**: Business Intelligence Discovery - `discover-insights` MCP tool - ✅ **COMPLETED**
-
-### Phase 3: Advanced Capabilities (Completed)
-- **Slice 3.1**: Schema Evolution Management - `track-schema-changes` MCP tool - ✅ **COMPLETED** (Phases 1-4 complete)
-- **Slice 3.2**: Advanced Data Profiling - Enhanced `analyze-schema` with optional `profiling` output - ✅ **COMPLETED**
-- **Slice 3.3**: Multi-Database Federation - `federated-query` MCP tool - ✅ **COMPLETED** (Phases 1-5 complete)
-
-### Detailed Planning Documents
-- **Enhancement Roadmap**: [roadmap.md](roadmap.md)
-- **Project Plan (History)**: [history/project-plan-roadmap.md](history/project-plan-roadmap.md)
-- **Vertical Slices (History)**: [history/vertical-slices.md](history/vertical-slices.md)
-- **Implementation Tasks (History)**: [history/implementation-tasks.md](history/implementation-tasks.md)
-
-### Traditional Roadmap Items
-#### Version 1.1 (Planned)
-- Enhanced connection pooling with dynamic sizing
-- Query result caching for improved performance
-- Additional database support (SQL Server, Oracle)
-- Advanced monitoring and metrics
-
-#### Version 1.2 (Future)
-- Multi-statement SQL execution
-- Transaction management
-- GraphQL query support
-- Advanced query optimization
-
-## Conclusion
-
-The Database MCP Server is fully production-ready with all MVP requirements completed and enhanced with additional features beyond the original scope. The implementation exceeds the performance, security, and usability requirements defined in the PRD.
-
-**Current Status: PRODUCTION READY WITH FEDERATION COMPLETE ✅**
-
-All core features and intelligence slices are implemented, tested, and documented. Phase 2 is complete (`analyze-data-lineage`, `discover-insights`), and Phase 3 is complete (`track-schema-changes`, advanced `analyze-schema` profiling, and `federated-query`). The system is currently in production use at version 1.0.7.
-
-**Next Steps**: Continue coverage hardening and release preparation for the next version increment.
+- Coverage hardening and regression prevention on newly added advanced features
+- Documentation and examples kept synchronized with runtime contracts

--- a/docs/lint-fix-plan-tdd.md
+++ b/docs/lint-fix-plan-tdd.md
@@ -2,8 +2,10 @@
 
 ## Document Metadata
 
+> Historical note: This document records a completed lint remediation campaign from 2026-02-06 and is kept for reference.
+
 **Created**: 2026-02-06
-**Status**: Planning - Awaiting Approval
+**Status**: Historical Reference (completed)
 **Lint Tool**: golangci-lint v2.8.0
 **Total Issues**: 29 (18 errcheck, 11 noctx)
 **Approach**: Test-Driven Development (TDD) with Session-Aware Checkpoints

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,6 +1,6 @@
-# Database MCP Provider – Product Requirements Document (PRD)
+# Database MCP Provider - Product Requirements Document (PRD)
 
-## 1. Introduction & Vision
+## 1. Introduction and Vision
 
 ### 1.1 Problem Statement
 Developers and AI agents face significant challenges when working with multiple databases:
@@ -11,227 +11,93 @@ Developers and AI agents face significant challenges when working with multiple 
 - Difficulty in providing database access to AI assistants safely
 
 ### 1.2 Proposed Solution
-The Database MCP Server provides a unified conversational API that allows AI agents and developers to interact with any supported SQL database through standardized MCP actions, abstracting away database-specific complexities.
+Database MCP Server provides a unified MCP tool interface that lets AI agents and developers interact with supported SQL databases using consistent contracts.
 
 ### 1.3 Key Goals
-- **Unified Access:** Single interface for MySQL, MariaDB, PostgreSQL, and SQLite
-- **Simplicity:** Action-based protocol for configuration and queries
-- **Security:** Credentials never stored or transmitted in plain text
-- **Statelessness:** No session state; scalable and robust
-- **Introspection:** Programmatic schema discovery for dynamic query generation
+- Unified access: one MCP interface for MySQL, MariaDB, PostgreSQL, SQLite
+- Simplicity: tool-based workflows for configuration, discovery, and querying
+- Security: encrypted credentials and policy-based read-only profiles
+- Introspection: programmatic schema and data understanding for agent workflows
 
 ## 2. User Personas
 
-### 2.1 AI Agent/Orchestrator
-- **Needs:** Seamless, autonomous access to multiple databases without managing drivers or authentication
-- **Pain Points:** Database-specific connection handling, credential management, SQL dialect differences
-- **Goals:** Execute queries, discover schemas, and analyze data across different database types
+### 2.1 AI Agent / Orchestrator
+- Needs: autonomous, consistent database access without custom per-database wiring
+- Goals: discover schema, generate/validate/optimize SQL, execute safely
 
 ### 2.2 Developer
-- **Needs:** Interact with various databases from an MCP-enabled environment without tool switching
-- **Pain Points:** Managing multiple database clients, connection overhead, context switching
-- **Goals:** Streamlined database access, consistent interface across database types
+- Needs: one interface across multiple databases inside MCP-capable coding tools
+- Goals: faster iteration, lower context switching, safer query workflows
 
-## 3. Features & Requirements
+## 3. Product Requirements
 
 ### 3.1 Core Requirements
 
 #### 3.1.1 Multi-Database Support
-- **Requirement:** Support for MySQL, MariaDB, PostgreSQL, and SQLite via a single MCP interface
-- **Acceptance Criteria:** All database types must support the same set of MCP actions with consistent behavior
+- Requirement: support MySQL, MariaDB, PostgreSQL, SQLite via one MCP interface
+- Acceptance: consistent tool behavior across supported backends
 
 #### 3.1.2 Connection Profile Management
-- **Interactive Setup:** On first run without `config.yaml`, guide users through CLI prompts to create connection profiles
-- **Profile Configuration:** Programmatic profile creation/update via `configure-profile` MCP action
-- **Profile Listing:** `list-profiles` action returns all configured profiles (name and type only, no sensitive data)
-- **Profile Deletion:** `delete-profile` action removes specified profile
-- **Profile Updates:** `update-profile` action modifies existing profile settings
+- Interactive first-run profile setup when config is missing
+- Programmatic profile create/update via `configure-profile`
+- Profile inventory via `list-profiles`
 
 #### 3.1.3 Database Interaction
-- **SQL Execution:** `execute-sql` action takes profile and SQL string, executes query, returns results
-- **Read-only Enforcement:** Optional read-only mode to prevent accidental data modification
-- **Cross-database Queries:** Support for fully qualified table names for cross-database operations
+- SQL execution via `execute-sql`
+- Read-only enforcement for protected profiles
+- Schema/database discovery: `list-databases`, `list-tables`, `describe-table`
 
-#### 3.1.4 Schema Introspection
-- **List Tables:** `list-tables` action returns all tables and views for a given profile
-- **List Databases:** `list-databases` action returns all databases/schemas for a given profile
-- **Describe Table:** `describe-table` action returns comprehensive column metadata including types, constraints, and comments
-- **Schema Analysis:** `analyze-schema` action provides multi-level schema analysis (BASIC, DETAILED, COMPREHENSIVE)
-
-#### 3.1.5 Data Discovery
-- **Sample Data:** `sample-data` action fetches sample rows from tables to infer data formats
-- **Join Discovery:** `discover-joins` action identifies foreign key relationships and suggests JOIN operations
-- **Smart Query Builder:** Natural language to SQL conversion with schema awareness
+#### 3.1.4 Intelligence and Governance
+- Query generation/validation/optimization:
+  - `smart-query-builder`
+  - `validate-query`
+  - `optimize-query`
+- Analysis and governance:
+  - `analyze-schema`
+  - `analyze-data-lineage`
+  - `discover-insights`
+  - `track-schema-changes`
+  - `federated-query`
 
 ### 3.2 Security Requirements
-
-#### 3.2.1 Credential Protection
-- **Encryption:** All passwords must be encrypted using AES-256-GCM
-- **Key Management:** 32-character encryption key stored securely (environment variable preferred)
-- **No Plaintext:** Credentials never stored or transmitted in plain text
-
-#### 3.2.2 Access Control
-- **Read-only Mode:** Configurable flag to prevent write operations
-- **SQL Injection Prevention:** All queries must use parameterized statements
-- **Permission Validation:** Database-level permissions enforced through connection configuration
+- AES-GCM encrypted credential storage
+- No plaintext credential logging
+- Read-only policy guardrails for exploration use cases
+- Parameterized statement support
 
 ### 3.3 Performance Requirements
-
-#### 3.3.1 Response Times
-- **Query Execution:** 95% of queries complete within 5 seconds
-- **Schema Introspection:** Table descriptions complete within 2 seconds
-- **Connection Setup:** New connections established within 1 second
-
-#### 3.3.2 Concurrency
-- **Connection Pooling:** Support for configurable connection pools
-- **Concurrent Requests:** Handle up to 50 simultaneous MCP actions
-- **Resource Limits:** Configurable limits on maximum connections per profile
-
-#### 3.3.3 Scalability
-- **Database Size:** Support databases up to 1TB without performance degradation
-- **Query Complexity:** Handle queries with up to 10 table JOINs efficiently
-- **Memory Usage:** Maximum 512MB RAM usage under normal load
+- Practical interactive responsiveness for normal analytical workloads
+- Connection pooling and stateless request handling
+- Configurable resource constraints (pool size, query limits)
 
 ### 3.4 Integration Requirements
-
-#### 3.4.1 MCP Protocol Compliance
-- **Standard Compliance:** Full compliance with Model Context Protocol specification
-- **Transport Layer:** Stdio communication only (no HTTP/network transport)
-- **JSON-RPC:** All communication via JSON-RPC over stdio
-
-#### 3.4.2 Client Integration
-- **Tool Discovery:** `list-tools` action provides complete machine-readable schema of all available tools
-- **Error Handling:** Structured error responses with actionable suggestions
-- **Logging:** Structured JSON logs for debugging and monitoring
+- MCP protocol compliance for client interoperability
+- Primary stdio transport with optional HTTP/SSE deployment path
+- Tool discovery via `list-tools`
+- Structured machine-usable error responses
 
 ### 3.5 Usability Requirements
-
-#### 3.5.1 Setup Experience
-- **Time to First Query:** < 5 minutes from installation to first successful query
-- **Interactive Setup:** CLI wizard for first-time configuration
-- **Validation:** Real-time validation of connection parameters
-
-#### 3.5.2 Documentation
-- **API Documentation:** Complete documentation for all MCP actions
-- **Configuration Examples:** Examples for all supported database types
-- **Troubleshooting Guide:** Common issues and resolution steps
+- Fast onboarding (<5 minutes to first successful query in common setups)
+- Clear examples for profile setup and tool workflows
+- Troubleshooting guidance for common connection/query failures
 
 ## 4. Success Metrics
+- Fast time to first successful query
+- Stable tool discovery and invocation across MCP clients
+- Zero plaintext credential storage incidents
+- High documentation discoverability for new users
 
-### 4.1 Adoption Metrics
-- **Time to First Query:** < 5 minutes for 90% of new users
-- **Setup Success Rate:** > 95% successful first-time setup
-- **Integration Success:** 100% compatibility with MCP-compliant clients
+## 5. Scope Boundaries
+- No GUI; MCP and CLI workflows only
+- No full ORM abstraction layer
+- Transaction orchestration remains database/client-driven
 
-### 4.2 Performance Metrics
-- **Query Response Time:** 95% of queries < 5 seconds
-- **System Availability:** > 99.9% uptime
-- **Resource Efficiency:** < 512MB RAM under normal load
-
-### 4.3 Quality Metrics
-- **Error Rate:** < 1% of operations result in unhandled errors
-- **Security Compliance:** Zero plaintext credential storage
-- **Documentation Completeness:** 100% of features documented with examples
-
-## 5. Out of Scope (V1)
-
-- No GUI interface (CLI and MCP only)
-- No automated schema migrations
-- No transaction management beyond atomic operations
-- No internal user access control (defer to DB permissions)
-- No embedded query builder or ORM beyond Smart Query Builder
-- No multi-statement SQL execution in single action
-- No HTTP or network transport protocols
-
-## 6. Risk Assessment
-
-### 6.1 Technical Risks
-- **Database Driver Compatibility:** Risk of driver version conflicts
-- **Performance Bottlenecks:** Risk of connection pool exhaustion
-- **Memory Leaks:** Risk of connection resource leaks
-
-### 6.2 Security Risks
-- **Credential Exposure:** Risk of encryption key compromise
-- **SQL Injection:** Risk of improper query parameterization
-- **Unauthorized Access:** Risk of credential theft
-
-### 6.3 Mitigation Strategies
-- **Regular Testing:** Comprehensive unit and integration tests
-- **Security Audits:** Regular security reviews and penetration testing
-- **Monitoring:** Real-time monitoring of resource usage and errors
-
-## 7. Dependencies
-
-### 7.1 Technical Dependencies
-- Go 1.25.5 runtime environment
+## 6. Technical Dependencies
+- Go runtime baseline: `go 1.25` (`go1.25.7` toolchain)
 - Official Go MCP SDK
-- Database drivers for MySQL, PostgreSQL, SQLite
-- AES-GCM encryption library
+- SQL database drivers for supported backends
 
-### 7.2 External Dependencies
-- Database servers (MySQL/MariaDB, PostgreSQL, SQLite)
-- MCP-compatible client applications
-- Operating system file system for configuration storage
-
-## 8. Release Criteria
-
-### 8.1 MVP Completion
-- All core requirements implemented and tested
-- Security requirements fully satisfied
-- Performance benchmarks met
-- Documentation complete and reviewed
-
-### 8.2 Production Readiness
-- Comprehensive test coverage (>90%)
-- Security audit completed
-- Performance testing completed
-- User acceptance testing passed
-
-## 9. Future Considerations
-
-### 9.1 Database Support
-- SQL Server support
-- Oracle database support
-- Amazon Redshift support
-- NoSQL database support
-
-### 9.2 Advanced Features
-- Multi-statement SQL execution
-- Transaction management
-- Enhanced connection pooling
-- Query optimization suggestions
-
-### 9.3 AI-Enhanced Capabilities (Based on PRD Analysis)
-
-#### 9.3.1 Query Intelligence
-- **Query Optimization**: Performance analysis and optimization suggestions
-- **Query Validation**: Syntax and logic validation without execution
-- **Execution Plan Analysis**: Deep query performance insights
-
-#### 9.3.2 Data Intelligence
-- **Data Lineage**: Dependency tracking and impact analysis
-- **Business Intelligence**: Automated KPI discovery and trend analysis
-- **Anomaly Detection**: Statistical outlier identification
-
-#### 9.3.3 Context Management
-- **Session Context**: Multi-turn conversation support
-- **Business Context**: Domain-aware query generation
-- **Learning System**: Query pattern optimization
-
-#### 9.3.4 Schema Management
-- **Schema Evolution**: Change tracking and migration assistance
-- **Advanced Profiling**: Statistical analysis and data quality metrics
-- **Cross-Database Federation**: Multi-database query capabilities
-
-### 9.4 Implementation Phases
-- **Phase 1** (Days 1-60): Foundation Intelligence features
-- **Phase 2** (Days 61-90): Business Intelligence capabilities
-- **Phase 3** (Days 91+): Advanced enterprise features
-
-See [Enhancement Roadmap](roadmap.md) for consolidated planning and [planning history](history/project-plan-roadmap.md) for comprehensive implementation strategy.
-
-### 9.3 Integration Enhancements
-- Additional transport protocols
-- Enhanced error recovery
-- Advanced monitoring and metrics
-- Automated failover support
+## 7. Future Considerations
+- Additional database support (e.g., SQL Server, Oracle)
+- Advanced observability and operational telemetry
+- Additional enterprise governance workflows

--- a/docs/tdd-implementation-plan.md
+++ b/docs/tdd-implementation-plan.md
@@ -12,7 +12,7 @@
 
 ## Executive Summary
 
-This document provides a Test-Driven Development (TDD) implementation plan for remaining planned capabilities in the Database MCP Server roadmap.
+This document records the Test-Driven Development (TDD) implementation for roadmap capabilities and tracks post-delivery hardening tasks.
 
 ### Current Implementation Status (Updated 2026-02-06)
 
@@ -28,7 +28,7 @@ This document provides a Test-Driven Development (TDD) implementation plan for r
 | Multi-Database Federation | `federated-query` | Phase 3 | ✅ **COMPLETED (Phases 1-5 complete)** | 2026-02-06 |
 
 **System Version**: v1.1.0 (Production Ready)  
-**Next Milestone**: Coverage hardening and release packaging for v1.0.8
+**Next Milestone**: Coverage hardening and release/package automation maintenance after v1.1.0.
 
 **F1 Completion Notes** (2026-02-06):
 - ✅ All TDD phases (1-4) completed for `discover-insights`

--- a/docs/technical-specifications.md
+++ b/docs/technical-specifications.md
@@ -2,767 +2,111 @@
 
 ## Overview
 
-This document provides detailed technical specifications for the Database MCP Server implementation, including architecture, data models, algorithms, and technical design decisions. Toolchain: Go 1.25.5.
+Database MCP Server is a production MCP provider for SQL databases, built in Go.
 
-**Transports**
-- Stdio (default)
-- HTTP/SSE (optional) via `MCP_SSE_ADDR` (e.g., `:8080`; start server with `MCP_SSE_ADDR=":8080" ./mcp-server`)
-  - Claude Desktop: add an MCP provider pointing to `http://localhost:8080` (SSE auto-detected).
-  - Codex CLI: if SSE supported, target the HTTP endpoint; otherwise use stdio (default).
-  - Kilocode: stdio by default; leave `MCP_SSE_ADDR` unset unless testing SSE.
+Current implementation baseline:
+- Runtime version: `v1.1.0`
+- Registered tools: `18`
+- Go module baseline: `go 1.25` (`toolchain go1.25.7`)
+- MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.2.0`
 
-## System Architecture
+## Runtime Architecture
 
-### High-Level Architecture
-
-```
-┌─────────────────────────────────────┐
-│         MCP Client (AI Agent)       │
-└─────────────────┬───────────────────┘
-                  │ stdio
-┌─────────────────┴───────────────────┐
-│          MCP Server Layer           │
-│    (internal/mcp/server.go)         │
-├─────────────────────────────────────┤
-│         Business Logic              │
-│  ┌─────────────┬─────────────────┐  │
-│  │   Config    │   Database      │  │
-│  │  Manager    │   Connector     │  │
-│  └─────────────┴─────────────────┘  │
-├─────────────────────────────────────┤
-│         Infrastructure              │
-│  ┌──────┬──────┬────────────────┐   │
-│  │ Log  │ AES  │ DB Drivers     │   │
-│  └──────┴──────┴────────────────┘   │
-└─────────────────────────────────────┘
+```text
+MCP Client
+  -> MCP Server Layer (internal/mcp)
+     -> Config Layer (internal/config)
+     -> DB Layer (internal/db)
+     -> Logging Layer (internal/log)
 ```
 
-### Component Architecture
-
-#### 1. MCP Server Layer (`internal/mcp/`)
-- **server.go**: Main MCP server implementation
-- **analyze_schema_types.go**: Type system for schema analysis
-- **errors.go**: Error handling and response formatting
-- **server_test.go**: Unit tests for MCP server
-
-#### 2. Configuration Management (`internal/config/`)
-- **config.go**: Profile and configuration management
-- **config_template.yaml**: Configuration template
-
-#### 3. Database Abstraction (`internal/db/`)
-- **driver.go**: Database connection management and abstraction
-
-#### 4. Logging Infrastructure (`internal/log/`)
-- **logger.go**: Structured JSON logging with rotation
-
-## Data Models
-
-### Configuration Data Models
-
-#### Profile Structure
-```go
-type Profile struct {
-    ProfileName string `yaml:"profile_name"`
-    DBType     string `yaml:"db_type"`     // mysql, postgresql, sqlite
-    Host       string `yaml:"host"`
-    Port       int    `yaml:"port"`
-    Username   string `yaml:"username"`
-    Password   string `yaml:"password"`     // encrypted
-    DatabaseName string `yaml:"database_name"`
-    ReadOnly   bool   `yaml:"readonly"`
-}
-```
-
-#### Configuration Structure
-```go
-type Config struct {
-    MaxPoolSize int       `yaml:"max_pool_size"`
-    AESKey      string    `yaml:"aes_key"`      // 32-character key
-    Profiles    []Profile `yaml:"profiles"`
-}
-```
-
-### MCP Action Data Models
-
-#### Standard Request Structure
-```go
-type MCPRequest struct {
-    Method string                 `json:"method"`
-    Params map[string]interface{} `json:"params"`
-    ID     interface{}           `json:"id"`
-}
-```
-
-#### Standard Response Structure
-```go
-type MCPResponse struct {
-    Result interface{} `json:"result,omitempty"`
-    Error  *MCPError   `json:"error,omitempty"`
-    ID     interface{} `json:"id"`
-}
-```
-
-#### Error Structure
-```go
-type MCPError struct {
-    Code        string                 `json:"code"`
-    Message     string                 `json:"message"`
-    Details     map[string]interface{} `json:"details,omitempty"`
-    Suggestions []string               `json:"suggestions,omitempty"`
-}
-```
-
-### Schema Analysis Data Models
-
-#### Column Information
-```go
-type ColumnInfo struct {
-    Name         string `json:"name"`
-    Type         string `json:"type"`
-    Nullable     bool   `json:"nullable"`
-    Key         string `json:"key"`
-    Default      *string `json:"default,omitempty"`
-    Extra        string `json:"extra,omitempty"`
-    Comment      string `json:"comment,omitempty"`
-    MaxLength    *int   `json:"max_length,omitempty"`
-    Precision    *int   `json:"precision,omitempty"`
-    Scale        *int   `json:"scale,omitempty"`
-    Charset      string `json:"charset,omitempty"`
-    Collation    string `json:"collation,omitempty"`
-}
-```
-
-#### Table Information
-```go
-type TableInfo struct {
-    Name        string       `json:"name"`
-    Type        string       `json:"type"`        // TABLE, VIEW
-    Columns     []ColumnInfo `json:"columns"`
-    RowCount    *int64      `json:"row_count,omitempty"`
-    Size        *int64       `json:"size,omitempty"`
-    Comment     string       `json:"comment,omitempty"`
-}
-```
-
-#### Schema Analysis Result
-```go
-type SchemaAnalysisResult struct {
-    Level              string                    `json:"level"`              // BASIC, DETAILED, COMPREHENSIVE
-    DatabaseName       string                    `json:"database_name"`
-    Tables            []TableInfo               `json:"tables"`
-    BusinessContext    *BusinessContext          `json:"business_context,omitempty"`
-    DataQuality       *DataQualityMetrics       `json:"data_quality,omitempty"`
-    Relationships     []RelationshipInfo        `json:"relationships,omitempty"`
-    QuerySuggestions  []QuerySuggestion         `json:"query_suggestions,omitempty"`
-}
-```
-
-## Algorithm Specifications
-
-### Connection Pooling Algorithm
-
-#### Pool Configuration
-```go
-func OpenConnectionWithPool(profile Profile) (*sql.DB, error) {
-    db, err := sql.Open(driverName, dsn)
-    if err != nil {
-        return nil, err
-    }
-    
-    // Configure pool based on config
-    db.SetMaxOpenConns(config.MaxPoolSize)
-    db.SetMaxIdleConns(config.MaxPoolSize / 2)
-    db.SetConnMaxLifetime(time.Hour)
-    db.SetConnMaxIdleTime(time.Minute * 30)
-    
-    return db, nil
-}
-```
-
-#### Connection Lifecycle
-1. **Connection Request**: Check pool for available connection
-2. **Pool Exhaustion**: Create new connection if under max limit
-3. **Connection Validation**: Ping before returning to client
-4. **Connection Return**: Return to pool after operation completion
-5. **Idle Cleanup**: Close connections idle for >30 minutes
-6. **Max Lifetime**: Close connections older than 1 hour
-
-### Encryption Algorithm
-
-#### AES-256-GCM Implementation
-```go
-func EncryptPassword(plaintext, key string) (string, error) {
-    block, err := aes.NewCipher([]byte(key))
-    if err != nil {
-        return "", err
-    }
-    
-    gcm, err := cipher.NewGCM(block)
-    if err != nil {
-        return "", err
-    }
-    
-    nonce := make([]byte, gcm.NonceSize())
-    if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
-        return "", err
-    }
-    
-    ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
-    return base64.StdEncoding.EncodeToString(ciphertext), nil
-}
-```
-
-#### Key Management
-- **Key Generation**: Cryptographically secure random 32-byte key
-- **Key Storage**: Environment variable `DB_MCP_AES_KEY` or config file
-- **Key Rotation**: Manual process requiring re-encryption of all passwords
-
-### Schema Analysis Algorithm
-
-#### Multi-Level Analysis Process
-
-##### BASIC Level
-1. **Table Discovery**: Query information_schema.tables
-2. **Column Enumeration**: Query information_schema.columns
-3. **Basic Metadata**: Extract name, type, nullability
-4. **Result Format**: Simple table/column structure
-
-##### DETAILED Level
-1. **BASIC Analysis**: Include all BASIC level information
-2. **Extended Metadata**: Add constraints, defaults, comments
-3. **Data Statistics**: Row counts, table sizes
-4. **Index Information**: Primary and foreign key information
-5. **Result Format**: Enhanced metadata with statistics
-
-##### COMPREHENSIVE Level
-1. **DETAILED Analysis**: Include all DETAILED level information
-2. **Business Context Inference**: Analyze naming patterns and relationships
-3. **Data Quality Assessment**: Check for null ratios, data patterns
-4. **Relationship Discovery**: Map foreign key relationships
-5. **Query Optimization**: Suggest indexes and query improvements
-6. **Result Format**: Complete analysis with actionable insights
-
-#### Business Context Inference Algorithm
-```go
-func InferBusinessContext(tables []TableInfo) *BusinessContext {
-    ctx := &BusinessContext{
-        Domain:        inferDomain(tables),
-        EntityTypes:   inferEntityTypes(tables),
-        Relationships: inferRelationships(tables),
-        DataPatterns:  inferDataPatterns(tables),
-    }
-    return ctx
-}
-
-func inferDomain(tables []TableInfo) string {
-    // Analyze table names, column names, and patterns
-    // Common domains: ecommerce, crm, analytics, etc.
-}
-```
-
-### SQL Parsing Algorithm
-
-#### Read-Only Enforcement
-```go
-func EnforceReadOnly(sql string) error {
-    // Parse SQL using simplified parser
-    tokens := tokenizeSQL(sql)
-    
-    for _, token := range tokens {
-        if isWriteOperation(token) {
-            return &MCPError{
-                Code:    "READONLY_VIOLATION",
-                Message: "Write operation not allowed in read-only profile",
-            }
-        }
-    }
-    return nil
-}
-
-func isWriteOperation(token string) bool {
-    writeOps := []string{"INSERT", "UPDATE", "DELETE", "DROP", "CREATE", "ALTER"}
-    upperToken := strings.ToUpper(token)
-    
-    for _, op := range writeOps {
-        if upperToken == op {
-            return true
-        }
-    }
-    return false
-}
-```
-
-## Database-Specific Implementations
-
-### MySQL/MariaDB Implementation
-
-#### Connection String Format
-```
-{username}:{password}@tcp({host}:{port})/{database_name}?parseTime=true&loc=Local
-```
-
-#### Schema Queries
-```sql
--- List tables
-SELECT table_name, table_type, table_comment 
-FROM information_schema.tables 
-WHERE table_schema = ? 
-ORDER BY table_name
-
--- Describe table
-SELECT 
-    column_name, 
-    data_type, 
-    is_nullable, 
-    column_key, 
-    column_default, 
-    extra, 
-    column_comment,
-    character_maximum_length,
-    numeric_precision,
-    numeric_scale,
-    character_set_name,
-    collation_name
-FROM information_schema.columns 
-WHERE table_schema = ? AND table_name = ?
-ORDER BY ordinal_position
-```
-
-### PostgreSQL Implementation
-
-#### Connection String Format
-```
-host={host} port={port} user={username} password={password} dbname={database_name} sslmode=disable
-```
-
-#### Schema Queries
-```sql
--- List tables
-SELECT 
-    t.table_name, 
-    CASE WHEN t.table_type = 'BASE TABLE' THEN 'TABLE' ELSE 'VIEW' END as table_type,
-    obj_description(c.oid) as table_comment
-FROM information_schema.tables t
-LEFT JOIN pg_class c ON c.relname = t.table_name
-WHERE t.table_schema = 'public'
-ORDER BY t.table_name
-
--- Describe table
-SELECT 
-    column_name, 
-    data_type, 
-    is_nullable, 
-    column_default, 
-    '' as column_key,
-    col_description(pgc.oid, cols.ordinal_position) as column_comment,
-    character_maximum_length,
-    numeric_precision,
-    numeric_scale
-FROM information_schema.columns cols
-LEFT JOIN pg_class pgc ON pgc.relname = cols.table_name
-WHERE cols.table_schema = 'public' AND cols.table_name = ?
-ORDER BY cols.ordinal_position
-```
-
-### SQLite Implementation
-
-#### Connection String Format
-```
-file:{database_path}?cache=shared&mode=rwc
-```
-
-#### Schema Queries
-```sql
--- List tables
-SELECT name, type FROM sqlite_master 
-WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'
-ORDER BY name
-
--- Describe table
-PRAGMA table_info({table_name})
-```
-
-## Performance Optimizations
-
-### Connection Pool Optimization
-
-#### Dynamic Pool Sizing
-```go
-func OptimizePoolSize(db *sql.DB, workload WorkloadType) {
-    switch workload {
-    case HighConcurrency:
-        db.SetMaxOpenConns(50)
-        db.SetMaxIdleConns(25)
-    case MemoryConstrained:
-        db.SetMaxOpenConns(10)
-        db.SetMaxIdleConns(5)
-    case Default:
-        db.SetMaxOpenConns(25)
-        db.SetMaxIdleConns(12)
-    }
-}
-```
-
-#### Query Optimization
-- **Prepared Statements**: Use prepared statements for repeated queries
-- **Result Streaming**: Stream large result sets to reduce memory usage
-- **Connection Reuse**: Maximize connection reuse through efficient pooling
-
-### Memory Management
-
-#### Result Set Handling
-```go
-func QueryWithLimit(db *sql.DB, query string, limit int) (*sql.Rows, error) {
-    // Add LIMIT clause if not present
-    if !strings.Contains(strings.ToUpper(query), "LIMIT") {
-        query = fmt.Sprintf("%s LIMIT %d", query, limit)
-    }
-    
-    return db.Query(query)
-}
-```
-
-#### Garbage Collection Optimization
-- **Object Pooling**: Reuse objects for frequent allocations
-- **Buffer Management**: Use sync.Pool for byte buffers
-- **Finalizer Avoidance**: Avoid finalizers for better GC performance
-
-## Security Implementation
-
-### Credential Protection
-
-#### Encryption Workflow
-1. **Key Generation**: Generate cryptographically secure 32-byte key
-2. **Password Encryption**: AES-256-GCM with random nonce
-3. **Storage**: Base64-encoded ciphertext in YAML
-4. **Decryption**: On-demand decryption for database connections
-5. **Memory Cleanup**: Zero plaintext from memory after use
-
-#### Access Control
-```go
-type SecurityContext struct {
-    ProfileName string
-    ReadOnly   bool
-    AllowedIPs []string
-    RateLimit  int
-}
-
-func ValidateAccess(ctx SecurityContext, request MCPRequest) error {
-    // Check read-only constraints
-    if ctx.ReadOnly && isWriteOperation(request) {
-        return ErrReadOnlyViolation
-    }
-    
-    // Check rate limits
-    if !checkRateLimit(ctx.ProfileName, ctx.RateLimit) {
-        return ErrRateLimitExceeded
-    }
-    
-    return nil
-}
-```
-
-### SQL Injection Prevention
-
-#### Parameterized Queries
-```go
-func ExecuteQuery(db *sql.DB, query string, params []interface{}) (*sql.Rows, error) {
-    // Always use prepared statements
-    stmt, err := db.Prepare(query)
-    if err != nil {
-        return nil, err
-    }
-    defer stmt.Close()
-    
-    return stmt.Query(params...)
-}
-```
-
-#### Query Validation
-```go
-func ValidateSQL(query string) error {
-    // Check for dangerous patterns
-    dangerousPatterns := []string{
-        "DROP", "DELETE", "UPDATE", "INSERT", 
-        "ALTER", "CREATE", "TRUNCATE",
-    }
-    
-    upperQuery := strings.ToUpper(query)
-    for _, pattern := range dangerousPatterns {
-        if strings.Contains(upperQuery, pattern) {
-            return fmt.Errorf("potentially dangerous SQL pattern detected: %s", pattern)
-        }
-    }
-    
-    return nil
-}
-```
-
-## Error Handling Strategy
-
-### Error Classification
-
-#### System Errors
-- **CONNECTION_FAILED**: Database connection failures
-- **TIMEOUT**: Query execution timeouts
-- **RESOURCE_EXHAUSTED**: Memory or connection pool exhaustion
-
-#### User Errors
-- **INVALID_PARAMETER**: Invalid request parameters
-- **PERMISSION_DENIED**: Insufficient database permissions
-- **SQL_SYNTAX_ERROR**: SQL syntax errors
-
-#### Business Logic Errors
-- **PROFILE_NOT_FOUND**: Requested profile doesn't exist
-- **TABLE_NOT_FOUND**: Requested table doesn't exist
-- **READONLY_VIOLATION**: Write operation on read-only profile
-
-### Error Response Format
-```go
-type ErrorResponse struct {
-    Status      string                 `json:"status"`
-    ErrorCode   string                 `json:"error_code"`
-    Message     string                 `json:"message"`
-    Details     map[string]interface{} `json:"details,omitempty"`
-    Suggestions []string               `json:"suggestions,omitempty"`
-    Context     ErrorContext           `json:"context,omitempty"`
-}
-```
-
-## Monitoring and Observability
-
-### Logging Strategy
-
-#### Log Levels
-- **ERROR**: System errors and failures
-- **WARN**: Warning conditions and recoverable errors
-- **INFO**: Important operational events
-- **DEBUG**: Detailed debugging information
-
-#### Log Format
-```json
-{
-  "timestamp": "2024-12-09T15:09:42Z",
-  "level": "INFO",
-  "component": "mcp-server",
-  "action": "execute-sql",
-  "profile_name": "production_db",
-  "duration_ms": 150,
-  "rows_affected": 42,
-  "error": null
-}
-```
-
-### Metrics Collection
-
-#### Performance Metrics
-- **Query Execution Time**: Histogram of query durations
-- **Connection Pool Usage**: Active/idle connection counts
-- **Error Rates**: Error counts by type and frequency
-- **Memory Usage**: Heap and GC statistics
-
-#### Business Metrics
-- **API Usage**: Request counts by endpoint
-- **User Activity**: Active profiles and usage patterns
-- **Database Access**: Most accessed tables and queries
-
-## Deployment Architecture
-
-### Container Deployment
-
-#### Docker Configuration
-```dockerfile
-FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine AS builder
-WORKDIR /src
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-ARG TARGETOS TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -trimpath -ldflags="-s -w" -o /out/database-mcp-server ./cmd/server/main.go
-
-FROM alpine:3.21
-RUN apk add --no-cache ca-certificates tzdata
-WORKDIR /app
-COPY --from=builder /out/database-mcp-server /usr/local/bin/database-mcp-server
-ENTRYPOINT ["/usr/local/bin/database-mcp-server"]
-```
-
-Published package image:
-- `ghcr.io/guyinwonder168/database-mcp-server:v1.0.7`
-- `ghcr.io/guyinwonder168/database-mcp-server:latest`
-
-#### Kubernetes Deployment
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: database-mcp-server
-spec:
-  replicas: 3
-  selector:
-    matchLabels:
-      app: database-mcp-server
-  template:
-    metadata:
-      labels:
-        app: database-mcp-server
-    spec:
-      containers:
-      - name: mcp-server
-        image: ghcr.io/guyinwonder168/database-mcp-server:latest
-        env:
-        - name: DB_MCP_AES_KEY
-          valueFrom:
-            secretKeyRef:
-              name: mcp-secrets
-              key: aes-key
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "250m"
-          limits:
-            memory: "512Mi"
-            cpu: "500m"
-```
-
-### Configuration Management
-
-#### Environment-Specific Configs
-- **Development**: Local databases, verbose logging
-- **Staging**: Production-like environment, reduced logging
-- **Production**: Optimized settings, security hardening
-
-#### Secret Management
-- **Encryption Keys**: Stored in Kubernetes secrets or AWS KMS
-- **Database Credentials**: Encrypted at rest, rotated regularly
-- **Access Control**: RBAC for secret access
+## Transports
+
+- Stdio: default and recommended for local/client process execution
+- HTTP/SSE: optional, enabled when `MCP_SSE_ADDR` is set
+
+## Core Components
+
+- `cmd/server/main.go`
+  - startup, config bootstrap, transport wiring
+- `internal/mcp/server.go`
+  - MCP server creation, tool registration, handlers
+- `internal/mcp/schema_tracker.go`
+  - schema tracking/history/migration/drift flows
+- `internal/mcp/federation_*.go`
+  - federated query parser/planner/executor/join logic
+- `internal/mcp/insights_*.go`
+  - insight discovery and statistics processing
+- `internal/config/config.go`
+  - profile persistence and encryption helpers
+- `internal/db/driver.go`
+  - database/sql DSN and pooled connection setup
+- `internal/log/logger.go`
+  - structured logging and rotation
+
+## Tool Surface (Implemented)
+
+The server registers these 18 tools:
+- `configure-profile`
+- `list-profiles`
+- `execute-sql`
+- `list-tables`
+- `describe-table`
+- `list-databases`
+- `analyze-schema`
+- `smart-query-builder`
+- `optimize-query`
+- `validate-query`
+- `analyze-data-lineage`
+- `discover-insights`
+- `track-schema-changes`
+- `federated-query`
+- `discover-joins`
+- `sample-data`
+- `mcp-info`
+- `list-tools`
+
+## Security Model
+
+- AES-GCM credential encryption at rest
+- Read-only profile enforcement for write protection
+- Parameterized SQL support (`params`) to reduce injection risk
+- Structured errors and safe logging (no raw credential output)
+
+## Performance Characteristics
+
+- Uses `database/sql` pooling via `SetMaxOpenConns` and `SetMaxIdleConns`
+- Stateless tool handlers for horizontal scaling compatibility
+- Query analysis tools (`optimize-query`, `validate-query`) separate planning from execution
+
+## Database Support
+
+- MySQL and MariaDB (`github.com/go-sql-driver/mysql v1.9.3`)
+- PostgreSQL (`github.com/lib/pq v1.11.1`)
+- SQLite (`github.com/mattn/go-sqlite3 v1.14.33`)
+
+## Packaging and Deployment
+
+### Container
+
+- Dockerfile is multi-stage and builds `./cmd/server/main.go`
+- Published images:
+  - `ghcr.io/guyinwonder168/database-mcp-server:v1.1.0`
+  - `ghcr.io/guyinwonder168/database-mcp-server:latest`
+
+### Release
+
+- GitHub Releases publish versioned binary assets by tag
+- GHCR package workflow publishes container images for tags
 
 ## Testing Strategy
 
-### Unit Testing
+- Unit tests adjacent to implementation (`*_test.go`)
+- Integration tests in `internal/mcp/*integration*_test.go`
+- Optional live DB tests through `DB_MCP_IT_*` environment variables
 
-#### Test Coverage Requirements
-- **Minimum Coverage**: 90% line coverage
-- **Critical Path Coverage**: 100% for security-critical components
-- **Error Path Testing**: All error conditions must be tested
+## Source-of-Truth Note
 
-#### Test Structure
-```go
-func TestExecuteSQL_Success(t *testing.T) {
-    // Setup
-    db := setupTestDB(t)
-    defer db.Close()
-    
-    // Test
-    result, err := ExecuteSQL(db, "SELECT 1 as test", []interface{}{})
-    
-    // Assert
-    assert.NoError(t, err)
-    assert.NotNil(t, result)
-}
-```
-
-### Integration Testing
-
-#### Database-Specific Tests
-- **MySQL Integration**: Test with MySQL 5.7, 8.0
-- **PostgreSQL Integration**: Test with PostgreSQL 10-16
-- **SQLite Integration**: Test with SQLite 3.8.0+
-- **Cross-Database Tests**: Verify consistent behavior
-
-#### MCP Protocol Tests
-- **Protocol Compliance**: Verify MCP specification compliance
-- **Error Handling**: Test error response formats
-- **Tool Discovery**: Verify tool listing functionality
-
-### Performance Testing
-
-#### Load Testing
-- **Concurrent Users**: Test with 100+ concurrent connections
-- **Query Performance**: Benchmark query execution times
-- **Memory Usage**: Monitor memory consumption under load
-- **Connection Pool**: Test pool efficiency under stress
-
-#### Stress Testing
-- **Resource Exhaustion**: Test behavior under resource constraints
-- **Error Recovery**: Test recovery from database failures
-- **Long-Running Tests**: Test stability over extended periods
-
-## Version Compatibility
-
-### Database Version Support
-
-#### MySQL/MariaDB
-- **MySQL**: 5.7+, 8.0+
-- **MariaDB**: 10.2+
-- **Features**: Full feature support across versions
-- **Limitations**: Some newer features may not be available in older versions
-
-#### PostgreSQL
-- **Supported Versions**: 10, 11, 12, 13, 14, 15, 16
-- **Feature Compatibility**: Core features available across all versions
-- **Version-Specific Features**: Leverage version-specific optimizations
-
-#### SQLite
-- **Minimum Version**: 3.8.0+
-- **Recommended Version**: 3.40.0+
-- **Feature Support**: Full feature support with latest versions
-
-### Go Version Compatibility
-
-#### Minimum Requirements
-- **Go Version**: 1.23.0+
-- **Build Tools**: Standard Go toolchain
-- **Dependencies**: Compatible with Go modules
-
-#### Compatibility Testing
-- **Multiple Go Versions**: Tested on Go 1.25.5 (current baseline)
-- **Platform Testing**: Linux, macOS, Windows
-- **Architecture Testing**: amd64, arm64
-
-### Enhancement Architecture Extensions
-
-#### New Component Requirements
-- **SQL Parser Library**: For query validation and optimization
-- **Statistical Analysis**: For business intelligence features
-- **Graph Processing**: For data lineage analysis
-- **NLP Integration**: For enhanced natural language processing
-- **Advanced Encryption**: For context and session data protection
-
-#### Performance Considerations
-- **Memory Usage**: Additional components will increase memory footprint
-- **CPU Usage**: Analytics and optimization features require more processing
-- **Storage**: Schema lineage and change tracking require metadata storage
-
-## Enhancement Architecture Evolution
-
-### Phase 1 Architecture Changes
-- **Query Optimization Engine**: New `internal/mcp/query_optimizer.go` component
-- **Validation Framework**: Extended `internal/mcp/query_validator.go` with syntax checking
-- **Context Management**: New `internal/mcp/context/` package for session state
-- **NLP Enhancement**: Extended `internal/mcp/nlp/` for intent classification
-
-### Phase 2 Architecture Changes
-- **Data Lineage Engine**: New `internal/mcp/lineage/` package for dependency analysis
-- **Analytics Framework**: New `internal/mcp/analytics/` package for statistical processing
-- **Business Intelligence**: KPI discovery and trend analysis capabilities
-
-### Phase 3 Architecture Changes
-- **Schema Evolution**: New `internal/mcp/schema/` package for change tracking
-- **Advanced Profiling**: Enhanced `internal/mcp/profiling/` for statistical analysis
-- **Federation Engine**: New `internal/mcp/federation/` package for cross-database operations
-
-### Backward Compatibility
-- **Existing Tools**: All 14 current MCP tools remain unchanged
-- **Configuration**: Extended YAML structure with feature flags
-- **API Protocol**: No changes to MCP JSON-RPC specification
-- **Database Drivers**: Existing driver abstraction supports all enhancements
-
-## Conclusion
-
-This technical specification provides a comprehensive overview of the Database MCP Server implementation and its planned evolution. The current architecture is production-ready and well-designed, with clear extension paths for AI-enhanced capabilities while maintaining backward compatibility.
-
-The implementation follows best practices for Go development, database connectivity, and MCP protocol compliance. The modular design allows for easy extension and maintenance while maintaining high performance and reliability.
-
-The enhancement roadmap maintains architectural integrity while adding sophisticated AI capabilities that will transform the Database MCP Server into an intelligent database interaction platform.
+If this document conflicts with runtime behavior, runtime code is authoritative:
+- `internal/mcp/server.go`
+- `docs/mcp-openapi.yaml`

--- a/docs/test-enhanced-schema.md
+++ b/docs/test-enhanced-schema.md
@@ -1,5 +1,7 @@
 # Enhanced Schema Introspection - Test Results
 
+> Historical note: This page documents the earlier enhancement milestone and is retained as implementation history.
+
 ## Implementation Summary
 
 I have successfully implemented TODO point #1: **Enhanced Schema Introspection Tool** with the following improvements:


### PR DESCRIPTION
## Summary
This PR synchronizes project documentation and memory-bank content with the **current runtime code state**.

## What Was Updated
- Synced active docs to `v1.1.0` and runtime `18`-tool surface.
- Replaced stale API/status/spec content that still referenced old tool counts and old versioning context.
- Updated memory-bank files to match current implementation and release/package reality.
- Added explicit **historical snapshot notes** to `docs/history/*` so historical plans are not confused with current contracts.
- Audited root `README.md` and `docs/README.md` for consistency with runtime registration.

## Files Updated
- `.kilocode/rules/memory-bank/architecture.md`
- `.kilocode/rules/memory-bank/brief.md`
- `.kilocode/rules/memory-bank/context.md`
- `.kilocode/rules/memory-bank/product.md`
- `.kilocode/rules/memory-bank/tech.md`
- `docs/README.md`
- `docs/analyze-schema-design.md`
- `docs/api-documentation.md`
- `docs/history/architecture-validation.md`
- `docs/history/implementation-roadmap.md`
- `docs/history/implementation-tasks.md`
- `docs/history/mcp-tool-detection-fix.md`
- `docs/history/project-plan-roadmap.md`
- `docs/history/vertical-slices.md`
- `docs/implementation-status.md`
- `docs/lint-fix-plan-tdd.md`
- `docs/prd.md`
- `docs/tdd-implementation-plan.md`
- `docs/technical-specifications.md`
- `docs/test-enhanced-schema.md`

## Validation
- Verified runtime tool registration count vs README tool table count (`18` vs `18`).
- Re-scanned docs/memory-bank for stale core claims (tool counts/version baselines) and cleaned active documents.
- Kept `docs/history/*` as historical references (annotated, not rewritten as current truth).

## Notes
- `wiki/` is a separate git repository and was not included in this main-repo PR.
