### PR TITLE
fix: update Dockerfile Go version to 1.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.26.0
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 


### PR DESCRIPTION
Fixes CI package build failure: `go: go.mod requires go >= 1.26 (running go 1.25.5)`