### PR TITLE
chore: bump version to v1.4.0 for PostgreSQL multi-schema release

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,3 +19,4 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           comment-summary-in-pr: always
+          retry-on-snapshot-warnings: true

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ pkg/log/*.log.*
 docs/plans/
 #exclude wiki from main repo
 wiki/
+
+# Test artifacts
+internal/mcp/test.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+## [v1.4.0] - 2026-03-30
+
+### Added
+- **PostgreSQL Multi-Schema Support**: Full schema awareness across all relevant MCP tools.
+  - `list-schemas` MCP tool to discover all accessible database schemas.
+  - `get-search-path` MCP tool for read-only diagnostic of current `search_path` and effective schema.
+  - `list-tables` now returns `[]TableRef` (schema + table name) instead of `[]string`.
+  - `describe-table`, `sample-data`, and `analyze-schema` accept optional `schema` parameter with auto-detection fallback (`current_schema()` → first accessible → `'public'`).
+  - Schema quoting via `pq.QuoteIdentifier()` for safe SQL interpolation.
+  - Default schema detection utility (`getDefaultSchema`) with graceful fallback chain.
+- Schema-aware tests converted to [go-sqlmock](https://github.com/DATA-DOG/go-sqlmock) for MySQL and PostgreSQL (no live DB required).
+- Coverage tests for schema resolution functions, table info scanning, and error paths.
+
+### Changed
+- Go toolchain bumped to 1.26.1.
+- `describePostgresTableColumns` refactored to use parameterized schema query (gosec G202 fix).
+- Extracted helper functions from `handleListSchemas` and `describePostgresTableColumns` to reduce cognitive complexity.
+- CI govulncheck step replaced with manual `go install` + `govulncheck ./...` to avoid intermittent `Duplicate header: Authorization` bug from `govulncheck-action`.
+
+### Fixed
+- Resolved SonarCloud `go:S107` (too many parameters) and `unparam` lint issues.
+- Resolved lint warnings in coverage tests.
+- Fixed gosec G202 (SQL string concatenation) by using parameterized queries for schema filtering.
+
 ## [v1.3.0] - 2026-02-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Go](https://img.shields.io/badge/Go-1.26.0%2B-00ADD8?logo=Go&logoColor=white)](https://go.dev)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-v1.3.0-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.3.0)
+[![Version](https://img.shields.io/badge/Version-v1.4.0-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.4.0)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 
-A production-ready Model Context Protocol (MCP) provider for SQL databases, built using various vibe coding tools. Supports MySQL, MariaDB, PostgreSQL, and SQLite. Features robust connection pooling, secure AES-GCM credential storage, structured JSON logging, comprehensive schema introspection, and a full suite of 19 MCP tools. Built and tested with Go 1.26.0.
+A production-ready Model Context Protocol (MCP) provider for SQL databases, built using various vibe coding tools. Supports MySQL, MariaDB, PostgreSQL, and SQLite. Features robust connection pooling, secure AES-GCM credential storage, structured JSON logging, comprehensive schema introspection, and a full suite of 21 MCP tools. Built and tested with Go 1.26.0.
 
 ## 🚀 Quick Start
 
@@ -28,10 +28,10 @@ go build -o mcp-server ./cmd/server/main.go
 
 ```bash
 # Pull the release image
-docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.3.0
+docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.4.0
 
 # Run with stdio transport
-docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.3.0
+docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.4.0
 ```
 
 ```bash
@@ -39,7 +39,7 @@ docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.3.0
 mkdir -p ./.mcp-data
 docker run --rm -i \
   -v "$(pwd)/.mcp-data:/app" \
-  ghcr.io/guyinwonder168/database-mcp-server:v1.3.0
+  ghcr.io/guyinwonder168/database-mcp-server:v1.4.0
 ```
 
 Package registry: `https://github.com/guyinwonder168/database-mcp-server/pkgs/container/database-mcp-server`
@@ -98,7 +98,7 @@ Package registry: `https://github.com/guyinwonder168/database-mcp-server/pkgs/co
 
 - Default schema mode is `compact` for tool-first and strict declaration-budget clients.
 - Optional `standard` mode keeps verbose tool descriptions for human-readable metadata.
-- All 19 MCP tools are always registered.
+- All 21 MCP tools are always registered.
 - **Gemini Compatibility**: Schemas are automatically sanitized to comply with Google Gemini's OpenAPI 3.0 subset requirements (single `type` values, no `additionalProperties: false`, proper `items` schemas).
 - Use `get-tool-help` for per-tool examples and troubleshooting without inflating startup metadata.
 
@@ -190,10 +190,10 @@ go test ./internal/mcp -run "TestLoadLineage" -v  # Lineage edge tests
 
 ## 📊 Project Status
 
-- **Version:** v1.3.0
+- **Version:** v1.4.0
 - **Built with:** Various vibe coding tools
 - **Status:** Production Ready ✅
-- All 19 MCP tools are fully implemented and OpenAPI-aligned.
+- All 21 MCP tools are fully implemented and OpenAPI-aligned.
 - Enhanced schema introspection and sample data features.
 - Optional advanced profiling in `analyze-schema` for column-level statistics, pattern detection, and quality scoring.
 - AES-GCM encryption, connection pooling, and structured error handling are enforced.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 This directory contains the canonical project documentation for the current production state.
 
 Current baseline:
-- Version: `v1.3.0`
+- Version: `v1.4.0`
 - MCP tools: `19` implemented and registered
 - Databases: MySQL, MariaDB, PostgreSQL, SQLite
 - Go baseline: `go 1.26` with toolchain `go1.26.0`

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,9 @@ This directory contains the canonical project documentation for the current prod
 
 Current baseline:
 - Version: `v1.4.0`
-- MCP tools: `19` implemented and registered
+- MCP tools: `21` implemented and registered
 - Databases: MySQL, MariaDB, PostgreSQL, SQLite
-- Go baseline: `go 1.26` with toolchain `go1.26.0`
+- Go baseline: `go 1.26` with toolchain `go1.26.1`
 
 ## Document Index
 

--- a/docs/implementation-status.md
+++ b/docs/implementation-status.md
@@ -6,10 +6,10 @@ This document tracks the current implementation status of the Database MCP Serve
 
 ## Project Information
 
-- Version: `v1.3.0`
+- Version: `v1.4.0`
 - Status: Production Ready
 - Author: `guyinwonder`
-- Toolchain: `go 1.26` with `go1.26.0`
+- Toolchain: `go 1.26` with `go1.26.1`
 - MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.2.0`
 - Distribution:
   - GitHub Releases (binary artifacts)
@@ -28,7 +28,7 @@ This document tracks the current implementation status of the Database MCP Serve
 
 ## MCP Tool Status (Runtime)
 
-The runtime currently registers **19 MCP tools**.
+The runtime currently registers **21 MCP tools**.
 
 | Tool | Status | Notes |
 |---|---|---|
@@ -50,6 +50,9 @@ The runtime currently registers **19 MCP tools**.
 | `sample-data` | ✅ Implemented | Sample rows for value/type inference |
 | `mcp-info` | ✅ Implemented | Provider metadata/version |
 | `list-tools` | ✅ Implemented | Runtime tool discovery |
+| `get-tool-help` | ✅ Implemented | Per-tool help, examples, and troubleshooting |
+| `list-schemas` | ✅ Implemented | List all accessible database schemas (PostgreSQL) |
+| `get-search-path` | ✅ Implemented | Current search_path and effective schema diagnostic |
 
 ## Implementation Phases
 
@@ -57,6 +60,7 @@ Roadmap slices are complete:
 - Phase 1 complete: `optimize-query`, `validate-query`, smart-query-builder enhancements
 - Phase 2 complete: `analyze-data-lineage`, `discover-insights`
 - Phase 3 complete: `track-schema-changes`, advanced `analyze-schema` profiling, `federated-query`
+- Phase 3.5 complete: PostgreSQL multi-schema support (`list-schemas`, `get-search-path`, schema-aware tools)
 
 ## Testing and Quality
 

--- a/docs/mcp-openapi.yaml
+++ b/docs/mcp-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Database MCP Provider API
-  version: "1.3.0"
+  version: "1.4.0"
   description: |
     OpenAPI documentation for all MCP tools exposed by the Database MCP Provider.
     This enables LLMs and clients to discover and use all available actions programmatically.

--- a/docs/technical-specifications.md
+++ b/docs/technical-specifications.md
@@ -5,9 +5,9 @@
 Database MCP Server is a production MCP provider for SQL databases, built in Go.
 
 Current implementation baseline:
-- Runtime version: `v1.3.0`
-- Registered tools: `19`
-- Go module baseline: `go 1.26` (`toolchain go1.26.0`)
+- Runtime version: `v1.4.0`
+- Registered tools: `21`
+- Go module baseline: `go 1.26` (`toolchain go1.26.1`)
 - MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.2.0`
 
 ## Runtime Architecture
@@ -92,7 +92,7 @@ The server registers these 19 tools:
 
 - Dockerfile is multi-stage and builds `./cmd/server/main.go`
 - Published images:
-  - `ghcr.io/guyinwonder168/database-mcp-server:v1.3.0`
+  - `ghcr.io/guyinwonder168/database-mcp-server:v1.4.0`
   - `ghcr.io/guyinwonder168/database-mcp-server:latest`
 
 ### Release

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -43,7 +43,7 @@ type MCPServer struct {
 	contextMgr    *ctxmgr.Manager
 }
 
-const MCPVersion = "v1.3.0"
+const MCPVersion = "v1.4.0"
 const MCPAuthor = "guyinwonder"
 
 // Cap for number of data quality issues retained per column to prevent unbounded payload growth

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=guyinwonder168
 
 # Project name and version
 sonar.projectName=Database MCP Server
-sonar.projectVersion=1.1.1
+sonar.projectVersion=1.4.0
 
 # Project description
 sonar.projectDescription=A production-ready Model Context Protocol (MCP) provider for SQL databases


### PR DESCRIPTION
## Summary

Version bump from v1.3.0 to **v1.4.0** to formalize the PostgreSQL multi-schema support feature merged in PR #52.

### Changes
- Bump `MCPVersion` to `"v1.4.0"` in `internal/mcp/server.go`
- Run `scripts/sync-version-from-server.sh` to auto-sync README.md + `docs/mcp-openapi.yaml`
- Add v1.4.0 section to `CHANGELOG.md` with full release notes
- Update tool count from 19 → 21 across all docs (README, implementation-status, technical-specifications)
- Add `list-schemas`, `get-search-path`, `get-tool-help` to implementation-status tool table
- Update `docs/README.md` and `docs/technical-specifications.md` version references
- Update GitHub Wiki pages (Home, Client-Setup-Guides, Installation-and-Quickstart, What-Is-Database-MCP-Server, Tool-Selection-Guide)

### v1.4.0 Highlights
- **PostgreSQL Multi-Schema Support**: `list-schemas`, `get-search-path`, schema-aware `list-tables`/`describe-table`/`sample-data`/`analyze-schema`
- Schema auto-detection fallback chain: `current_schema()` → first accessible → `'public'`
- Tests converted to go-sqlmock for MySQL/PostgreSQL
- CI govulncheck fix (replaced action with manual steps)
- Go toolchain bumped to 1.26.1

### Verification
- [x] `go build` passes
- [x] `go vet` passes
- [x] All version refs in sync (server.go, README, OpenAPI, CHANGELOG, docs)
- [x] Wiki pages updated and pushed