### PR TITLE
chore: bump Go toolchain to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
           cache: true
 
       - name: Download dependencies
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
           cache: true
 
       - name: Run go vet
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Run Gosec Security Scanner
         uses: securego/gosec@223e19b8856e00f02cc67804499a83f77e208f3c # v2.25.0
@@ -170,7 +170,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Run integration tests (Postgres)
         env:
@@ -238,7 +238,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
 
       - name: Build binary
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.2'
           cache: true
 
       - name: Download dependencies

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module database-mcp-provider
 
 go 1.26
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary
- Bump Go toolchain from 1.26.1 → 1.26.2 to fix 4 stdlib vulnerabilities detected by govulncheck

## Vulnerabilities Fixed
| ID | Vulnerability | Package |
|----|--------------|---------|
| GO-2026-4947 | Unexpected work during chain building | crypto/x509 |
| GO-2026-4946 | Inefficient policy validation | crypto/x509 |
| GO-2026-4870 | TLS 1.3 KeyUpdate DoS | crypto/tls |
| GO-2026-4866 | Case-sensitive excludedSubtrees Auth Bypass | crypto/x509 |

## Changes
- `go.mod`: toolchain go1.26.1 → go1.26.2
- `.github/workflows/ci.yml`: go-version 1.26.1 → 1.26.2 (5 occurrences)
- `.github/workflows/sonarcloud.yml`: go-version 1.26.1 → 1.26.2

## Verification
- `go mod tidy` passes
- All changes are stdlib patch version only — no code changes needed