### PR TITLE
chore: bump version to v1.5.0

### DIFF
--- a/.kilocode/rules/memory-bank/architecture.md
+++ b/.kilocode/rules/memory-bank/architecture.md
@@ -6,6 +6,9 @@
 MCP Client
   -> MCP Server Layer (internal/mcp)
      -> Analyze Package (internal/mcp/analyze)
+     -> Lineage Package (internal/mcp/lineage)
+     -> NLP Package (internal/mcp/nlp)
+     -> Context Package (internal/mcp/context)
      -> Config Layer (internal/config)
      -> DB Layer (internal/db)
      -> Logging Layer (internal/log)
@@ -24,6 +27,8 @@ MCP Client
   - registration of 20 tools
   - core handlers for profile, SQL, schema, and metadata operations
   - thin handler for analyze-schema (delegates to analyze.Run())
+- `analyze_schema_types.go`
+  - shared types for analyze-schema request/response
 - `insights_*.go`
   - KPI/trend/anomaly/distribution analysis
 - `schema_tracker*.go`, `schema_storage.go`, `schema_migrations.go`
@@ -32,15 +37,39 @@ MCP Client
   - federated query parsing, planning, execution, result joins
 - `errors.go`
   - structured error analysis and suggestions
+- `tool_help.go`
+  - tool description/help metadata generation
+- `query_validator.go`, `query_optimizer.go`, `performance_estimator.go`
+  - query validation, optimization, and performance estimation
+- `profiling_engine.go`, `profiling_types.go`
+  - data profiling engine for analyze-schema
+- `optimization_rules.go`
+  - optimization rule definitions
+- `helpers.go`
+  - shared helper functions
 
 ### Analyze Package (`internal/mcp/analyze`)
-- `analyzer.go` — Run() orchestration function coordinating the full analysis pipeline
-- `columns.go` — Bulk column fetching (MySQL/PostgreSQL/SQLite)
+- `analyzer.go` — Run() orchestration, table schema building, relationship graph, classification signals
+- `columns.go` — Bulk column fetching with parameterized queries (TVF for SQLite)
 - `relationships.go` — Real FK discovery, implicit relationships, relationship graph building
 - `performance.go` — Index analysis, performance optimization recommendations
 - `enrichment.go` — Business context inference, data pattern recognition, quality metrics, table categorization
 - `rows.go` — Sample row fetching and normalization
+- `sanitize.go` — SQL identifier validation and per-DB quoting helpers
 - `types.go` — Shared types (TableInfo, SchemaColumnInfo, DataPattern, etc.)
+- `doc.go` — Package documentation
+
+### Lineage Package (`internal/mcp/lineage`)
+- `analyzer.go` — Data lineage analysis
+- `dependency_graph.go` — Table dependency graph construction
+
+### NLP Package (`internal/mcp/nlp`)
+- `entity_extractor.go` — Entity extraction for natural language queries
+- `intent_classifier.go` — Intent classification for smart-query-builder
+
+### Context Package (`internal/mcp/context`)
+- `manager.go` — Conversation context management
+- `conversation.go` — Conversation state tracking
 
 ### Configuration Layer (`internal/config`)
 - encrypted profile persistence (AES-GCM)
@@ -74,7 +103,9 @@ MCP Client
 2. Tool-based MCP contracts for interoperability
 3. Read-only policy as first-class guardrail
 4. Separation of concern between handler orchestration and feature-specific engines
-5. Pure functions in analyze package — no MCPServer dependencies for testability
+5. Pure functions in analyze/lineage/nlp/context packages — no MCPServer dependencies for testability
+6. SQL injection prevention via `sanitizeIdentifier()` + `quoteForDB()` + parameterized queries
+7. SQLite PRAGMAs accessed via table-valued functions for parameterized queries
 
 ## File Layout (High-Level)
 
@@ -84,6 +115,9 @@ MCP Client
 - `internal/log/*`
 - `internal/mcp/*`
 - `internal/mcp/analyze/*`
+- `internal/mcp/lineage/*`
+- `internal/mcp/nlp/*`
+- `internal/mcp/context/*`
 - `docs/*`
 - `.kilocode/rules/memory-bank/*`
 

--- a/.kilocode/rules/memory-bank/brief.md
+++ b/.kilocode/rules/memory-bank/brief.md
@@ -5,7 +5,7 @@
 Database MCP Server is a production-ready MCP provider for SQL databases, implemented in Go. It exposes a unified tool interface so AI agents and developers can safely interact with MySQL, MariaDB, PostgreSQL, and SQLite.
 
 Current implementation state:
-- Version: `v1.4.0`
+- Version: `v1.5.0`
 - MCP tools: `20` implemented and registered
 - Packaging: GitHub Releases + GHCR container images
 

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- Version: `v1.4.0`
+- Version: `v1.5.0`
 - Stage: Production-ready
 - Toolchain: `go 1.26` with `go1.26.2`
 - MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.5.0`
@@ -29,20 +29,28 @@
 
 ### Analyze Package (`internal/mcp/analyze/`)
 Dedicated package for `analyze-schema` logic, extracted from server.go:
-- `analyzer.go` — Run() orchestration function
-- `columns.go` — Bulk column fetching (MySQL/PostgreSQL/SQLite)
+- `analyzer.go` — Run() orchestration, buildTableSchemas, buildRelationshipGraph, buildClassificationSignals
+- `columns.go` — Bulk column fetching (MySQL/PostgreSQL/SQLite) with parameterized TVF queries
 - `relationships.go` — Real FK discovery, implicit relationships, relationship graph
 - `performance.go` — Index analysis, performance optimization recommendations
 - `enrichment.go` — Business context, data patterns, quality metrics, table categorization
 - `rows.go` — Sample row fetching and normalization
+- `sanitize.go` — `sanitizeIdentifier()`, `quoteMySQL()`, `quotePostgres()`, `quoteSQLite()`, `quoteForDB()`
 - `types.go` — Shared types for the analyze pipeline
+- `doc.go` — Package documentation
 
 Server.go has a thin handler that delegates to `analyze.Run()`, keeping only MCP-specific code (query suggestions via smart-builder, profiling).
 
-### Key Refactoring (v1.3.0–v1.4.0)
+### Additional Sub-Packages
+- `internal/mcp/lineage/` — Data lineage analyzer and dependency graph
+- `internal/mcp/nlp/` — Entity extractor and intent classifier for smart-query-builder
+- `internal/mcp/context/` — Conversation context manager
+
+### Key Refactoring (v1.4.0–v1.5.0)
 - Extracted ~40 functions from server.go into `internal/mcp/analyze/` as pure functions
-- Fixed 6 analyze-schema bugs (#75–#80): column scanning, FK discovery, implicit relationships, classification signals, index analysis
-- Bug fix: SemanticTypeRegexes regex overlap resolved with ordered matching
+- Fixed 6 analyze-schema bugs (#75–#80): column scanning, FK discovery, implicit relationships, classification signals, index analysis, regex overlap
+- Security hardening: all `fmt.Sprintf` SQL eliminated, SQLite PRAGMAs converted to parameterized TVF, `sanitizeIdentifier()` + `quoteForDB()` added
+- Extracted 8 helper functions for cognitive complexity reduction (SonarCloud S3776)
 
 ## Gemini Compatibility
 
@@ -54,11 +62,11 @@ Server.go has a thin handler that delegates to `analyze.Run()`, keeping only MCP
 
 - Release workflow publishes GitHub Releases from tags
 - Package workflow publishes GHCR container images
-- Latest release line currently aligned at `v1.4.0`
+- Latest release line currently aligned at `v1.5.0`
 
 ## Documentation State
 
-- Root README aligned with `v1.4.0` and 20 tools
+- Root README aligned with `v1.5.0` and 20 tools
 - docs/ updated to reflect current runtime behavior
 - Wiki expanded with onboarding, tool-scenario mapping, and client setup guides
 

--- a/.kilocode/rules/memory-bank/product.md
+++ b/.kilocode/rules/memory-bank/product.md
@@ -40,13 +40,13 @@ Database MCP Server provides a unified MCP tool interface with consistent behavi
 ## Supported Tool Surface
 
 The product currently exposes 20 tools, spanning:
-- profile/connectivity,
-- schema discovery,
-- SQL execution,
-- query intelligence,
-- lineage/insight/schema governance,
-- cross-profile federation,
-- runtime metadata.
+- **Profile/connectivity**: `configure-profile`, `list-profiles`
+- **Schema discovery**: `list-databases`, `list-tables`, `describe-table`, `list-schemas`, `get-search-path`, `discover-joins`, `sample-data`
+- **SQL execution**: `execute-sql`
+- **Query intelligence**: `smart-query-builder`, `validate-query`, `optimize-query`
+- **Analysis/governance**: `analyze-schema` (with optional profiling), `discover-insights`, `analyze-data-lineage`, `track-schema-changes`
+- **Federation**: `federated-query`
+- **Runtime metadata**: `list-tools`, `get-tool-help`, `mcp-info`
 
 ## Success Metrics
 

--- a/.kilocode/rules/memory-bank/tech.md
+++ b/.kilocode/rules/memory-bank/tech.md
@@ -32,7 +32,9 @@
 
 - AES-GCM password encryption
 - Per-profile read-only mode
-- Parameterized query support for execution paths
+- SQL injection prevention via `sanitizeIdentifier()` + `quoteForDB()` helpers
+- Parameterized queries throughout (including SQLite TVF for PRAGMAs)
+- No `fmt.Sprintf` in SQL construction paths
 
 ## Build and Test Commands
 
@@ -54,11 +56,20 @@ DB_MCP_IT_PG_HOST=... DB_MCP_IT_PG_DB=... go test ./internal/mcp -run TestLive -
 - GitHub Releases for binaries
 - GHCR package: `ghcr.io/guyinwonder168/database-mcp-server`
 
+## Version Sync
+
+- Source of truth: `MCPVersion` constant in `internal/mcp/server.go`
+- Sync script: `scripts/sync-version-from-server.sh` updates README.md and `docs/mcp-openapi.yaml`
+- Must be run after any version bump
+
 ## Current Capability Surface
 
 - 20 MCP tools implemented
 - Full coverage of profile management, schema discovery, SQL execution, intelligence tools, schema tracking, and federation
 - Dedicated `internal/mcp/analyze/` package for schema analysis logic
+- Dedicated `internal/mcp/lineage/` for data lineage
+- Dedicated `internal/mcp/nlp/` for natural language processing
+- Dedicated `internal/mcp/context/` for conversation management
 
 ## Source of Truth
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+## [v1.5.0] - 2026-04-19
+
+### Changed
+- **Extracted `internal/mcp/analyze/` package**: ~40 functions refactored out of `server.go` into a dedicated, testable package with pure functions (no MCPServer dependencies).
+- **Security hardening**: Eliminated all `fmt.Sprintf` SQL patterns (SonarCloud S2077). SQLite PRAGMAs converted to parameterized table-valued functions. Added `sanitizeIdentifier()`, `quoteMySQL()`, `quotePostgres()`, `quoteSQLite()`, and `quoteForDB()` helpers for safe SQL identifier handling.
+- **Cognitive complexity reduction** (SonarCloud S3776): Extracted 8 private helper functions across `analyzer.go`, `performance.go`, `relationships.go`, and `server.go` to bring all functions below complexity threshold.
+- **CI workflow hardening** (S6439): Moved `${{ }}` expressions to `env:` blocks in release workflow to prevent script injection.
+
+### Fixed
+- **Bug #75**: Column scanning — fixed column metadata extraction for all database types.
+- **Bug #76**: FK discovery — fixed foreign key relationship detection.
+- **Bug #77**: Implicit relationships — fixed column-to-table matching for implicit FK inference.
+- **Bug #78**: Classification signals — fixed signal extraction for LLM-based domain inference.
+- **Bug #79**: Index analysis — fixed index metadata parsing for PostgreSQL and SQLite.
+- **Bug #80**: Semantic type regex overlap — resolved with ordered matching.
+- All SonarCloud quality gate issues resolved (S2077, S3776, S6439, gosec G201/G202).
+
 ## [v1.4.0] - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go](https://img.shields.io/badge/Go-1.26.0%2B-00ADD8?logo=Go&logoColor=white)](https://go.dev)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-v1.4.0-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.4.0)
+[![Version](https://img.shields.io/badge/Version-v1.5.0-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.5.0)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
@@ -28,10 +28,10 @@ go build -o mcp-server ./cmd/server/main.go
 
 ```bash
 # Pull the release image
-docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.4.0
+docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.5.0
 
 # Run with stdio transport
-docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.4.0
+docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.5.0
 ```
 
 ```bash
@@ -39,7 +39,7 @@ docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.4.0
 mkdir -p ./.mcp-data
 docker run --rm -i \
   -v "$(pwd)/.mcp-data:/app" \
-  ghcr.io/guyinwonder168/database-mcp-server:v1.4.0
+  ghcr.io/guyinwonder168/database-mcp-server:v1.5.0
 ```
 
 Package registry: `https://github.com/guyinwonder168/database-mcp-server/pkgs/container/database-mcp-server`
@@ -190,7 +190,7 @@ go test ./internal/mcp -run "TestLoadLineage" -v  # Lineage edge tests
 
 ## 📊 Project Status
 
-- **Version:** v1.4.0
+- **Version:** v1.5.0
 - **Built with:** Various vibe coding tools
 - **Status:** Production Ready ✅
 - All 21 MCP tools are fully implemented and OpenAPI-aligned.

--- a/docs/mcp-openapi.yaml
+++ b/docs/mcp-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Database MCP Provider API
-  version: "1.4.0"
+  version: "1.5.0"
   description: |
     OpenAPI documentation for all MCP tools exposed by the Database MCP Provider.
     This enables LLMs and clients to discover and use all available actions programmatically.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -43,7 +43,7 @@ type MCPServer struct {
 	contextMgr    *ctxmgr.Manager
 }
 
-const MCPVersion = "v1.4.0"
+const MCPVersion = "v1.5.0"
 const MCPAuthor = "guyinwonder"
 
 const sqliteListTablesQuery = "SELECT name FROM sqlite_master WHERE type='table'"


### PR DESCRIPTION
## Summary

- Bump `MCPVersion` from `v1.4.0` → `v1.5.0` in `internal/mcp/server.go`
- Sync version to `README.md` (badge, release link, container tags) and `docs/mcp-openapi.yaml` via `scripts/sync-version-from-server.sh`
- Add `v1.5.0` CHANGELOG entry covering PR #82 changes (analyze-schema refactoring, security hardening, bug fixes #75–#80, cognitive complexity reduction, CI workflow fix)
- Update all `.kilocode/rules/memory-bank/` files to reflect current architecture, sub-packages, and security patterns

## Changes

| File | Change |
|------|--------|
| `internal/mcp/server.go` | `MCPVersion` → `v1.5.0` |
| `README.md` | Version badge, release link, container tag → `v1.5.0` |
| `docs/mcp-openapi.yaml` | `info.version` → `1.5.0` |
| `CHANGELOG.md` | Added `v1.5.0` section |
| `.kilocode/rules/memory-bank/*.md` | Updated all 5 files to current codebase state |

## Test

- `go vet ./...` — clean
- No code logic changes (version bump + docs only)