### PR TITLE
chore: bump version to v1.5.1

### DIFF
--- a/.kilocode/rules/memory-bank/architecture.md
+++ b/.kilocode/rules/memory-bank/architecture.md
@@ -27,8 +27,9 @@ MCP Client
   - registration of 20 tools
   - core handlers for profile, SQL, schema, and metadata operations
   - thin handler for analyze-schema (delegates to analyze.Run())
+  - `resolveSchemaForAnalyze` — schema resolution with database name for MySQL/MariaDB, `current_schema()` for PostgreSQL
 - `analyze_schema_types.go`
-  - shared types for analyze-schema request/response
+  - shared types for analyze-schema request/response (including `Warnings []string` for privilege detection)
 - `insights_*.go`
   - KPI/trend/anomaly/distribution analysis
 - `schema_tracker*.go`, `schema_storage.go`, `schema_migrations.go`
@@ -87,7 +88,7 @@ MCP Client
 
 ### Registered Tools (20)
 - `configure-profile`, `list-profiles`, `execute-sql`
-- `list-tables`, `describe-table`, `list-databases`, `list-schemas`, `get-search-path`
+- `list-tables`, `describe-table`, `list-databases`, `get-search-path`
 - `analyze-schema`, `smart-query-builder`, `discover-joins`, `sample-data`
 - `optimize-query`, `validate-query`, `analyze-data-lineage`, `discover-insights`
 - `track-schema-changes`, `federated-query`

--- a/.kilocode/rules/memory-bank/brief.md
+++ b/.kilocode/rules/memory-bank/brief.md
@@ -5,7 +5,7 @@
 Database MCP Server is a production-ready MCP provider for SQL databases, implemented in Go. It exposes a unified tool interface so AI agents and developers can safely interact with MySQL, MariaDB, PostgreSQL, and SQLite.
 
 Current implementation state:
-- Version: `v1.5.0`
+- Version: `v1.5.1`
 - MCP tools: `20` implemented and registered
 - Packaging: GitHub Releases + GHCR container images
 
@@ -18,7 +18,7 @@ Provide a secure, practical, and discoverable MCP database interface that works 
 1. Multi-database connectivity (MySQL, MariaDB, PostgreSQL, SQLite)
 2. Profile configuration and listing (`configure-profile`, `list-profiles`)
 3. SQL execution with read-only policy enforcement (`execute-sql`)
-4. Schema discovery (`list-databases`, `list-tables`, `describe-table`, `list-schemas`, `get-search-path`, `discover-joins`)
+4. Schema discovery (`list-databases`, `list-tables`, `describe-table`, `get-search-path`, `discover-joins`)
 5. Data sampling and analysis (`sample-data`, `analyze-schema`, `discover-insights`)
 6. Query intelligence (`smart-query-builder`, `validate-query`, `optimize-query`)
 7. Governance and advanced workflows (`analyze-data-lineage`, `track-schema-changes`, `federated-query`)

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- Version: `v1.5.0`
+- Version: `v1.5.1`
 - Stage: Production-ready
 - Toolchain: `go 1.26` with `go1.26.2`
 - MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.5.0`
@@ -13,7 +13,7 @@
 - Core DB workflow:
   - `configure-profile`, `list-profiles`, `execute-sql`
   - `list-databases`, `list-tables`, `describe-table`
-  - `list-schemas`, `get-search-path`, `discover-joins`, `sample-data`
+  - `get-search-path`, `discover-joins`, `sample-data`
 - Query intelligence:
   - `smart-query-builder`, `validate-query`, `optimize-query`
 - Analysis/governance:
@@ -46,9 +46,10 @@ Server.go has a thin handler that delegates to `analyze.Run()`, keeping only MCP
 - `internal/mcp/nlp/` — Entity extractor and intent classifier for smart-query-builder
 - `internal/mcp/context/` — Conversation context manager
 
-### Key Refactoring (v1.4.0–v1.5.0)
+### Key Refactoring (v1.4.0–v1.5.1)
 - Extracted ~40 functions from server.go into `internal/mcp/analyze/` as pure functions
-- Fixed 6 analyze-schema bugs (#75–#80): column scanning, FK discovery, implicit relationships, classification signals, index analysis, regex overlap
+- Fixed MySQL/MariaDB schema resolution bug (#75–#80): `resolveSchemaForAnalyze` now passes `databaseName` instead of empty string
+- Added `Warnings []string` to `AnalyzeSchemaResult` for privilege detection
 - Security hardening: all `fmt.Sprintf` SQL eliminated, SQLite PRAGMAs converted to parameterized TVF, `sanitizeIdentifier()` + `quoteForDB()` added
 - Extracted 8 helper functions for cognitive complexity reduction (SonarCloud S3776)
 
@@ -62,11 +63,11 @@ Server.go has a thin handler that delegates to `analyze.Run()`, keeping only MCP
 
 - Release workflow publishes GitHub Releases from tags
 - Package workflow publishes GHCR container images
-- Latest release line currently aligned at `v1.5.0`
+- Latest release line currently aligned at `v1.5.1`
 
 ## Documentation State
 
-- Root README aligned with `v1.5.0` and 20 tools
+- Root README aligned with `v1.5.1` and 20 tools
 - docs/ updated to reflect current runtime behavior
 - Wiki expanded with onboarding, tool-scenario mapping, and client setup guides
 

--- a/.kilocode/rules/memory-bank/product.md
+++ b/.kilocode/rules/memory-bank/product.md
@@ -41,7 +41,7 @@ Database MCP Server provides a unified MCP tool interface with consistent behavi
 
 The product currently exposes 20 tools, spanning:
 - **Profile/connectivity**: `configure-profile`, `list-profiles`
-- **Schema discovery**: `list-databases`, `list-tables`, `describe-table`, `list-schemas`, `get-search-path`, `discover-joins`, `sample-data`
+- **Schema discovery**: `list-databases`, `list-tables`, `describe-table`, `get-search-path`, `discover-joins`, `sample-data`
 - **SQL execution**: `execute-sql`
 - **Query intelligence**: `smart-query-builder`, `validate-query`, `optimize-query`
 - **Analysis/governance**: `analyze-schema` (with optional profiling), `discover-insights`, `analyze-data-lineage`, `track-schema-changes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+## [v1.5.1] - 2026-04-19
+
+### Fixed
+- **Bug #75**: `analyze-schema` returned 0 columns for MySQL/MariaDB — `resolveSchemaForAnalyze` now correctly passes `databaseName` for MySQL/MariaDB instead of empty string.
+- **Bug #76**: `analyze-schema` returned 0 row counts for MySQL/MariaDB — root cause same as #75 (empty `TABLE_SCHEMA` filter).
+- **Bug #77**: `analyze-schema` returned 0 foreign keys for MySQL/MariaDB — root cause same as #75.
+- **Bug #78**: Domain detection showed "unknown" for all databases — cascading from 0 columns; classification signals now populate correctly.
+- **Bug #79**: All tables categorized as "core" (100%) — cascading from 0 columns; proper categorization restored.
+- **Bug #80**: `analyze-schema` returned only generic tips with no query patterns or index recommendations — cascading from 0 columns; full analysis restored.
+- Added `Warnings []string` field to `AnalyzeSchemaResult` for non-fatal privilege warnings.
+- Added post-analysis privilege detection: warns when tables exist but 0 columns are accessible (likely insufficient database privileges).
+
 ## [v1.5.0] - 2026-04-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Go](https://img.shields.io/badge/Go-1.26.0%2B-00ADD8?logo=Go&logoColor=white)](https://go.dev)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-v1.5.0-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.5.0)
+[![Version](https://img.shields.io/badge/Version-v1.5.1-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.5.1)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 
-A production-ready Model Context Protocol (MCP) provider for SQL databases, built using various vibe coding tools. Supports MySQL, MariaDB, PostgreSQL, and SQLite. Features robust connection pooling, secure AES-GCM credential storage, structured JSON logging, comprehensive schema introspection, and a full suite of 21 MCP tools. Built and tested with Go 1.26.0.
+A production-ready Model Context Protocol (MCP) provider for SQL databases, built using various vibe coding tools. Supports MySQL, MariaDB, PostgreSQL, and SQLite. Features robust connection pooling, secure AES-GCM credential storage, structured JSON logging, comprehensive schema introspection, and a full suite of 20 MCP tools. Built and tested with Go 1.26.0.
 
 ## 🚀 Quick Start
 
@@ -28,10 +28,10 @@ go build -o mcp-server ./cmd/server/main.go
 
 ```bash
 # Pull the release image
-docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.5.0
+docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.5.1
 
 # Run with stdio transport
-docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.5.0
+docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.5.1
 ```
 
 ```bash
@@ -39,7 +39,7 @@ docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.5.0
 mkdir -p ./.mcp-data
 docker run --rm -i \
   -v "$(pwd)/.mcp-data:/app" \
-  ghcr.io/guyinwonder168/database-mcp-server:v1.5.0
+  ghcr.io/guyinwonder168/database-mcp-server:v1.5.1
 ```
 
 Package registry: `https://github.com/guyinwonder168/database-mcp-server/pkgs/container/database-mcp-server`
@@ -98,7 +98,7 @@ Package registry: `https://github.com/guyinwonder168/database-mcp-server/pkgs/co
 
 - Default schema mode is `compact` for tool-first and strict declaration-budget clients.
 - Optional `standard` mode keeps verbose tool descriptions for human-readable metadata.
-- All 21 MCP tools are always registered.
+- All 20 MCP tools are always registered.
 - **Gemini Compatibility**: Schemas are automatically sanitized to comply with Google Gemini's OpenAPI 3.0 subset requirements (single `type` values, no `additionalProperties: false`, proper `items` schemas).
 - Use `get-tool-help` for per-tool examples and troubleshooting without inflating startup metadata.
 
@@ -190,10 +190,10 @@ go test ./internal/mcp -run "TestLoadLineage" -v  # Lineage edge tests
 
 ## 📊 Project Status
 
-- **Version:** v1.5.0
+- **Version:** v1.5.1
 - **Built with:** Various vibe coding tools
 - **Status:** Production Ready ✅
-- All 21 MCP tools are fully implemented and OpenAPI-aligned.
+- All 20 MCP tools are fully implemented and OpenAPI-aligned.
 - Enhanced schema introspection and sample data features.
 - Optional advanced profiling in `analyze-schema` for column-level statistics, pattern detection, and quality scoring.
 - AES-GCM encryption, connection pooling, and structured error handling are enforced.

--- a/docs/mcp-openapi.yaml
+++ b/docs/mcp-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Database MCP Provider API
-  version: "1.5.0"
+  version: "1.5.1"
   description: |
     OpenAPI documentation for all MCP tools exposed by the Database MCP Provider.
     This enables LLMs and clients to discover and use all available actions programmatically.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -53,7 +53,7 @@ Database MCP Server provides a unified MCP tool interface that lets AI agents an
   - `validate-query`
   - `optimize-query`
 - Analysis and governance:
-  - `analyze-schema`
+  - `analyze-schema` (with LLM-based domain inference via classification signals and privilege warnings)
   - `analyze-data-lineage`
   - `discover-insights`
   - `track-schema-changes`
@@ -101,4 +101,4 @@ Database MCP Server provides a unified MCP tool interface that lets AI agents an
 - Additional database support (e.g., SQL Server, Oracle)
 - Advanced observability and operational telemetry
 - Additional enterprise governance workflows
-- **Data Migration (v1.4.0)** - Cross-database migration with async jobs, schema translation, and resume capability (see `docs/data-migration-design.md`)
+- **Data Migration (Phase 4)** - Cross-database migration with async jobs, schema translation, and resume capability (see `docs/data-migration-design.md`)

--- a/docs/technical-specifications.md
+++ b/docs/technical-specifications.md
@@ -5,8 +5,8 @@
 Database MCP Server is a production MCP provider for SQL databases, built in Go.
 
 Current implementation baseline:
-- Runtime version: `v1.4.0`
-- Registered tools: `21`
+- Runtime version: `v1.5.1`
+- Registered tools: `20`
 - Go module baseline: `go 1.26` (`toolchain go1.26.1`)
 - MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.2.0`
 
@@ -31,10 +31,14 @@ MCP Client
   - startup, config bootstrap, transport wiring
 - `internal/mcp/server.go`
   - MCP server creation, tool registration, handlers
+  - Schema resolution for analyze operations (`resolveSchemaForAnalyze`)
+  - Privilege warning detection for MySQL/MariaDB/PostgreSQL
 - `internal/mcp/schema_tracker.go`
   - schema tracking/history/migration/drift flows
 - `internal/mcp/federation_*.go`
   - federated query parser/planner/executor/join logic
+- `internal/mcp/analyze_*.go`, `internal/mcp/analyze_schema_types.go`
+  - analyze-schema request/response types, including `Warnings []string` for privilege issues
 - `internal/mcp/insights_*.go`
   - insight discovery and statistics processing
 - `internal/config/config.go`
@@ -46,13 +50,14 @@ MCP Client
 
 ## Tool Surface (Implemented)
 
-The server registers these 19 tools:
+The server registers these 20 tools:
 - `configure-profile`
 - `list-profiles`
 - `execute-sql`
 - `list-tables`
 - `describe-table`
 - `list-databases`
+- `get-search-path`
 - `analyze-schema`
 - `smart-query-builder`
 - `optimize-query`
@@ -73,6 +78,9 @@ The server registers these 19 tools:
 - Read-only profile enforcement for write protection
 - Parameterized SQL support (`params`) to reduce injection risk
 - Structured errors and safe logging (no raw credential output)
+- Schema-aware query construction: `resolveSchemaForAnalyze` correctly passes database name for MySQL/MariaDB (not empty string)
+- Privilege detection warnings in `analyze-schema` response (`Warnings []string`) when tables exist but columns are inaccessible
+- Domain inference via classification signals (not hardcoded domain patterns) — LLM-based domain detection from raw table/column signals
 
 ## Performance Characteristics
 
@@ -92,7 +100,7 @@ The server registers these 19 tools:
 
 - Dockerfile is multi-stage and builds `./cmd/server/main.go`
 - Published images:
-  - `ghcr.io/guyinwonder168/database-mcp-server:v1.4.0`
+  - `ghcr.io/guyinwonder168/database-mcp-server:v1.5.1`
   - `ghcr.io/guyinwonder168/database-mcp-server:latest`
 
 ### Release

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -43,7 +43,7 @@ type MCPServer struct {
 	contextMgr    *ctxmgr.Manager
 }
 
-const MCPVersion = "v1.5.0"
+const MCPVersion = "v1.5.1"
 const MCPAuthor = "guyinwonder"
 
 const sqliteListTablesQuery = "SELECT name FROM sqlite_master WHERE type='table'"
@@ -1029,7 +1029,7 @@ func (s *MCPServer) handleMCPInfo(ctx context.Context, _ *mcp.CallToolRequest, i
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			&mcp.TextContent{
-				Text: "Database MCP Provider\nAuthor: " + MCPAuthor + "\nVersion: " + MCPVersion + "\nCreated using Opus 4.6, GLM 5, and GPT 5.3-Codex via OpenAgent framework.\nFeatures: 19 tools (including profile delete/clone), optimized for strict declaration budgets.",
+				Text: "Database MCP Provider\nAuthor: " + MCPAuthor + "\nVersion: " + MCPVersion + "\nBuilt via OpenAgent framework with multiple AI models (Claude, GLM, GPT, etc.).\nFeatures: 20 tools (including profile delete/clone), optimized for strict declaration budgets.",
 			},
 		},
 	}, nil, nil


### PR DESCRIPTION
## Summary

Version bump from v1.5.0 to v1.5.1, reflecting the MySQL/MariaDB schema resolution fix (PR #84, issues #75-#80).

### Changes

**Version synchronization (v1.5.0 → v1.5.1):**
- `internal/mcp/server.go` — `MCPVersion` constant
- `README.md` — version badge, docker tags, project status
- `docs/mcp-openapi.yaml` — `info.version`
- `CHANGELOG.md` — new v1.5.1 section with all 6 bug fixes

**Documentation alignment:**
- Fixed tool count: 20 registered (was incorrectly 21 in README/docs, 19 in mcp-info)
- Updated `docs/prd.md` — `analyze-schema` now uses LLM-based classification signals + privilege warnings; Data Migration labeled as Phase 4
- Updated `docs/technical-specifications.md` — added `resolveSchemaForAnalyze`, privilege detection, classification signals, corrected tool list
- Updated `.kilocode/rules/memory-bank/` — version, architecture, refactoring notes, tool lists

**Code fixes found during audit:**
- `mcp-info` description: replaced hardcoded model versions with generic "multiple AI models (Claude, GLM, GPT, etc.)"

### Files changed
| File | Change |
|------|--------|
| `internal/mcp/server.go` | MCPVersion, mcp-info description |
| `README.md` | Version badge, docker tags, tool count |
| `CHANGELOG.md` | v1.5.1 entry |
| `docs/mcp-openapi.yaml` | info.version |
| `docs/prd.md` | analyze-schema description, Phase 4 label |
| `docs/technical-specifications.md` | Version, tools, security notes |
| `.kilocode/rules/memory-bank/*.md` | Version, architecture, tool lists |

### Related
- Closes #75, #76, #77, #78, #79, #80 (via PR #84)
- See #85 (OpenAPI spec missing 9 tool definitions — separate issue)