### PR TITLE
fix: register list-schemas tool and complete OpenAPI spec

### DIFF
--- a/.kilocode/rules/memory-bank/architecture.md
+++ b/.kilocode/rules/memory-bank/architecture.md
@@ -24,7 +24,7 @@ MCP Client
 ### MCP Layer (`internal/mcp`)
 - `server.go`
   - server initialization
-  - registration of 20 tools
+  - registration of 21 tools
   - core handlers for profile, SQL, schema, and metadata operations
   - thin handler for analyze-schema (delegates to analyze.Run())
   - `resolveSchemaForAnalyze` — schema resolution with database name for MySQL/MariaDB, `current_schema()` for PostgreSQL

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -57,7 +57,7 @@ Server.go has a thin handler that delegates to `analyze.Run()`, keeping only MCP
 
 - JSON schemas are automatically sanitized for Google Gemini's OpenAPI 3.0 subset requirements.
 - Schema mode `compact` is the default for tool-first clients.
-- All 20 tools are compatible with Gemini function calling.
+- All 21 tools are compatible with Gemini function calling.
 
 ## Packaging and Release State
 
@@ -67,7 +67,7 @@ Server.go has a thin handler that delegates to `analyze.Run()`, keeping only MCP
 
 ## Documentation State
 
-- Root README aligned with `v1.5.1` and 20 tools
+- Root README aligned with `v1.5.1` and 21 tools
 - docs/ updated to reflect current runtime behavior
 - Wiki expanded with onboarding, tool-scenario mapping, and client setup guides
 

--- a/.kilocode/rules/memory-bank/product.md
+++ b/.kilocode/rules/memory-bank/product.md
@@ -39,7 +39,7 @@ Database MCP Server provides a unified MCP tool interface with consistent behavi
 
 ## Supported Tool Surface
 
-The product currently exposes 20 tools, spanning:
+The product currently exposes 21 tools, spanning:
 - **Profile/connectivity**: `configure-profile`, `list-profiles`
 - **Schema discovery**: `list-databases`, `list-tables`, `describe-table`, `get-search-path`, `discover-joins`, `sample-data`
 - **SQL execution**: `execute-sql`

--- a/.kilocode/rules/memory-bank/tech.md
+++ b/.kilocode/rules/memory-bank/tech.md
@@ -64,7 +64,7 @@ DB_MCP_IT_PG_HOST=... DB_MCP_IT_PG_DB=... go test ./internal/mcp -run TestLive -
 
 ## Current Capability Surface
 
-- 20 MCP tools implemented
+- 21 MCP tools implemented
 - Full coverage of profile management, schema discovery, SQL execution, intelligence tools, schema tracking, and federation
 - Dedicated `internal/mcp/analyze/` package for schema analysis logic
 - Dedicated `internal/mcp/lineage/` for data lineage

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 
-A production-ready Model Context Protocol (MCP) provider for SQL databases, built using various vibe coding tools. Supports MySQL, MariaDB, PostgreSQL, and SQLite. Features robust connection pooling, secure AES-GCM credential storage, structured JSON logging, comprehensive schema introspection, and a full suite of 20 MCP tools. Built and tested with Go 1.26.0.
+A production-ready Model Context Protocol (MCP) provider for SQL databases, built using various vibe coding tools. Supports MySQL, MariaDB, PostgreSQL, and SQLite. Features robust connection pooling, secure AES-GCM credential storage, structured JSON logging, comprehensive schema introspection, and a full suite of 21 MCP tools. Built and tested with Go 1.26.0.
 
 ## 🚀 Quick Start
 
@@ -98,7 +98,7 @@ Package registry: `https://github.com/guyinwonder168/database-mcp-server/pkgs/co
 
 - Default schema mode is `compact` for tool-first and strict declaration-budget clients.
 - Optional `standard` mode keeps verbose tool descriptions for human-readable metadata.
-- All 20 MCP tools are always registered.
+- All 21 MCP tools are always registered.
 - **Gemini Compatibility**: Schemas are automatically sanitized to comply with Google Gemini's OpenAPI 3.0 subset requirements (single `type` values, no `additionalProperties: false`, proper `items` schemas).
 - Use `get-tool-help` for per-tool examples and troubleshooting without inflating startup metadata.
 
@@ -193,7 +193,7 @@ go test ./internal/mcp -run "TestLoadLineage" -v  # Lineage edge tests
 - **Version:** v1.5.1
 - **Built with:** Various vibe coding tools
 - **Status:** Production Ready ✅
-- All 20 MCP tools are fully implemented and OpenAPI-aligned.
+- All 21 MCP tools are fully implemented and OpenAPI-aligned.
 - Enhanced schema introspection and sample data features.
 - Optional advanced profiling in `analyze-schema` for column-level statistics, pattern detection, and quality scoring.
 - AES-GCM encryption, connection pooling, and structured error handling are enforced.

--- a/docs/bug-tracker-analyze-schema.md
+++ b/docs/bug-tracker-analyze-schema.md
@@ -1,0 +1,300 @@
+# Bug Tracker — `analyze-schema` Accuracy Issues
+
+> **Parent**: [bug-tracker.md](./bug-tracker.md)
+> **Discovered**: 2026-04-16
+> **Test Database**: CSS (MariaDB) — 114 tables, 904 columns, 96 FK relationships
+
+Bugs discovered during comprehensive `analyze-schema` run against the CSS database. The tool produces output but with significant accuracy problems that make automated analysis unreliable.
+
+---
+
+## BUG-004: `analyze-schema` — Column Count Massively Underreported
+
+| Field | Details |
+|-------|---------|
+| **Tool** | `analyze-schema` |
+| **Severity** | High — fundamental metadata inaccuracy |
+| **Status** | Open |
+| **Date Reported** | 2026-04-16 |
+| **Reproducibility** | 100% (MariaDB, profile `css-mariadb`) |
+
+### Problem
+
+Reports **362 columns** when the actual count is **904 columns** (60% underreporting).
+
+### Evidence
+
+```
+Expected: 904 columns (verified via SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA='css')
+Reported: 362 columns (analyze-schema output: "total_columns": 362)
+```
+
+### Root Cause
+
+The tool relies on `describe-table` for column enumeration. Tables with 0 sample rows (54 of 114 tables) show **0 columns** in the output:
+
+```
+activation_link_mapping: 0 columns  (actual: multiple)
+adm_account_role_groups: 0 columns  (actual: multiple)
+broadcast_customer_room_links: 0 columns  (actual: multiple)
+...
+```
+
+The `describe-table` step appears to skip or fail silently on empty tables, and `analyze-schema` does not fall back to `information_schema.COLUMNS`.
+
+### Expected Behavior
+
+Column count should match `SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ?` regardless of whether tables contain data.
+
+### Suggested Fix
+
+1. **Primary**: Query `information_schema.COLUMNS` directly for column counts (independent of sample data)
+2. **Fallback**: If `describe-table` returns 0 columns, cross-check against `information_schema.COLUMNS`
+3. **Validation**: Add assertion: if `list-tables` returns N tables but column total is suspiciously low, log a warning
+
+---
+
+## BUG-005: `analyze-schema` — Row Counts All Zero
+
+| Field | Details |
+|-------|---------|
+| **Tool** | `analyze-schema` |
+| **Severity** | High — table size analysis completely broken |
+| **Status** | Open |
+| **Date Reported** | 2026-04-16 |
+| **Reproducibility** | 100% (MariaDB, profile `css-mariadb`) |
+
+### Problem
+
+All 114 tables report **0 rows** in `table_schemas`, even though many tables have data (60 tables returned sample data, largest has 310K rows).
+
+### Evidence
+
+```
+table_schemas output:
+  user_id_hashes: 0 rows   (actual: 310,200)
+  adm_audit_log: 0 rows    (actual: 8,532)
+  customers: 0 rows        (actual: 158)
+  user_ids: 0 rows         (actual: 176)
+```
+
+### Root Cause
+
+The tool populates `row_count` from sample data retrieval only. It does NOT query:
+- `information_schema.TABLES.TABLE_ROWS` (fast, estimated)
+- `SELECT COUNT(*) FROM table` (accurate, slower)
+
+The `row_count` field in `table_schemas` is never populated from metadata.
+
+### Expected Behavior
+
+Row counts should be populated from `information_schema.TABLES.TABLE_ROWS` at minimum, with optional `SELECT COUNT(*)` for accurate counts at higher analysis levels.
+
+### Suggested Fix
+
+1. **Basic analysis**: Query `SELECT TABLE_NAME, TABLE_ROWS FROM information_schema.TABLES WHERE TABLE_SCHEMA = ?`
+2. **Detailed/Comprehensive**: Run `SELECT COUNT(*)` for accurate counts (with timeout protection)
+3. **Profiled tables**: Use `sample_row_count` from column profiling as a secondary indicator
+
+---
+
+## BUG-006: `analyze-schema` — Foreign Key Relationships Not Detected
+
+| Field | Details |
+|-------|---------|
+| **Tool** | `analyze-schema` (via `discover-joins`) |
+| **Severity** | High — relationship analysis produces false positives, zero true positives |
+| **Status** | Open |
+| **Date Reported** | 2026-04-16 |
+| **Reproducibility** | 100% (MariaDB, profile `css-mariadb`) |
+
+### Problem
+
+The tool detected **2,336 relationships** — all classified as `shared_column` with 0.6 confidence. **Zero** actual foreign key relationships were detected, despite 96 real FKs existing in the database.
+
+### Evidence
+
+```
+Detected:  2,336 relationships, ALL "shared_column" type, ALL 0.6 confidence
+Actual FKs: 96 foreign keys (verified via information_schema.KEY_COLUMN_USAGE)
+
+Example false positive:
+  customers JOIN user_id_hashes ON customers.created = user_id_hashes.created
+  (WRONG — should be ON user_id_hashes.i_customer = customers.id)
+```
+
+The tool suggests joining tables on `created` timestamps — a column present in nearly every table — producing thousands of meaningless relationships.
+
+### Root Cause
+
+The `discover-joins` / relationship detection logic uses column-name matching to infer relationships. It does NOT query actual FK metadata from:
+- `information_schema.KEY_COLUMN_USAGE` (FK definitions)
+- `information_schema.REFERENTIAL_CONSTRAINTS` (constraint details)
+
+Column-name matching on common names like `created`, `i_realm`, `id` produces massive false positives.
+
+### Expected Behavior
+
+1. **Primary**: Query `information_schema.KEY_COLUMN_USAGE` for real FK relationships (100% accurate)
+2. **Secondary**: Use column-name matching only as "suggested" relationships with lower confidence
+3. **Separate**: Clearly distinguish between "foreign key" (verified) and "shared column" (inferred)
+
+### Suggested Fix
+
+1. Add FK discovery via `information_schema`:
+   ```sql
+   SELECT 
+     TABLE_NAME, COLUMN_NAME,
+     REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
+   FROM information_schema.KEY_COLUMN_USAGE
+   WHERE TABLE_SCHEMA = ? AND REFERENCED_TABLE_NAME IS NOT NULL
+   ```
+2. Label FK relationships as `foreign_key` with 1.0 confidence
+3. Label column-name matches as `shared_column` with 0.3 confidence (not 0.6)
+4. **Never** suggest joins on `created`/`modified` timestamp columns
+5. Deprioritize joins on generic columns (`id`, `i_realm`) unless FK-verified
+
+---
+
+## BUG-007: `analyze-schema` — Domain Misclassification
+
+| Field | Details |
+|-------|---------|
+| **Tool** | `analyze-schema` |
+| **Severity** | Medium — business context analysis misleading |
+| **Status** | Open |
+| **Date Reported** | 2026-04-16 |
+| **Reproducibility** | 100% (MariaDB, profile `css-mariadb`) |
+
+### Problem
+
+Classifies the CSS database as **"CRM"** with confidence 3/5. The actual domain is a **SIP/VoIP communication platform** (multi-tenant PBX with messaging, push notifications, device provisioning).
+
+### Evidence
+
+```
+Detected:  "crm" (confidence: 3.00)
+Actual:    SIP/VoIP multi-tenant communication platform
+
+Strong domain indicators present but missed:
+  - sipuser, sip_password, sip_use_anonymous_registration
+  - call_destinations, call_rates, call_recordings
+  - pushtokens, push_url
+  - broadcast_channels, broadcast_messages
+  - turnservers, verto_secret
+  - xmpp (cross-database references)
+  - device provisioning (autoconfig, bundle_id_autoconfig_mapping)
+```
+
+### Root Cause
+
+The domain classifier uses table name pattern matching. It correctly identifies `snake_case` naming but doesn't have SIP/VoIP domain patterns in its dictionary.
+
+### Suggested Fix
+
+1. Add SIP/VoIP domain patterns: `sip*`, `call_*`, `push*`, `broadcast*`, `turn*`, `xmpp*`, `autoconfig*`, `voip*`
+2. Add communication platform indicators: `devices`, `realms`, `feature_groups`, `whitelist*`
+3. Weight table count by domain: 6 call tables + 9 broadcast tables + 7 device tables should strongly indicate VoIP, not CRM
+
+---
+
+## BUG-008: `analyze-schema` — Entity Classification Too Generic
+
+| Field | Details |
+|-------|---------|
+| **Tool** | `analyze-schema` |
+| **Severity** | Medium — table catalog not useful |
+| **Status** | Open |
+| **Date Reported** | 2026-04-16 |
+| **Reproducibility** | 100% |
+
+### Problem
+
+Table catalog classifies **86 of 114 tables (75%)** as `"other"`, making the categorization useless:
+
+```
+core_entities: 106 tables
+lookup_tables:  2 tables
+audit_tables:   6 tables
+
+Entity roles within core_entities:
+  "other":         86 tables (75%)
+  "master_data":  20 tables (18%)
+  "log":           6 tables (5%)
+  "lookup":        2 tables (2%)
+```
+
+### Expected Behavior
+
+Tables should be classified into meaningful categories:
+- `customer_management`: customers, user_ids, devices, contacts
+- `telephony`: call_destinations, call_rates, call_recordings, e164
+- `messaging`: broadcast_channels, broadcast_messages, metadata_group
+- `administration`: adm_accounts, adm_role, dashboard_users
+- `provisioning`: autoconfig, bundle_id_autoconfig_mapping, turnservers
+- `security`: 2fa_checks, brute_force_lock, auth_tokens, preauthkeys
+
+### Suggested Fix
+
+1. Expand entity role taxonomy beyond 4 categories
+2. Use table name prefixes (`adm_*`, `broadcast_*`, `address_book_*`, `realm_*`) for classification
+3. Use FK relationships (once BUG-006 is fixed) to infer entity roles from connectivity
+
+---
+
+## BUG-009: `analyze-schema` — `performance_optimization` Returns Empty
+
+| Field | Details |
+|-------|---------|
+| **Tool** | `analyze-schema` |
+| **Severity** | Low — advertised feature produces no output |
+| **Status** | Open |
+| **Date Reported** | 2026-04-16 |
+| **Reproducibility** | 100% |
+
+### Problem
+
+The `performance_optimization` section returns `{"query_patterns": {}}` — completely empty despite running at `comprehensive` level.
+
+### Expected Behavior
+
+Should include:
+- Missing index recommendations (tables with no indexes on FK columns)
+- Composite index suggestions (multi-column WHERE clauses)
+- Table scan warnings (large tables without indexes)
+- Query pattern analysis from stored procedures (if accessible)
+
+### Suggested Fix
+
+1. Query `information_schema.STATISTICS` for existing indexes
+2. Cross-reference with `information_schema.KEY_COLUMN_USAGE` for FK columns lacking indexes
+3. For `comprehensive` level, run `EXPLAIN` on sample queries for large tables
+4. Check for tables > 10K rows without indexes on frequently-joined columns
+
+---
+
+## Summary
+
+| Bug | Severity | Area | Impact |
+|-----|----------|------|--------|
+| BUG-004 | High | Column count | 60% underreporting (362 vs 904) |
+| BUG-005 | High | Row counts | All zero — size analysis broken |
+| BUG-006 | High | FK detection | 0 real FKs found, 2336 false positives |
+| BUG-007 | Medium | Domain | Misclassifies VoIP as CRM |
+| BUG-008 | Medium | Classification | 75% tables labeled "other" |
+| BUG-009 | Low | Performance | Empty output |
+
+### Fix Priority
+
+| Priority | Bugs | Effort | Dependencies |
+|----------|------|--------|-------------|
+| **P0** | BUG-006 (FK detection) | Medium | None — enables BUG-008 |
+| **P0** | BUG-004 (Column count) | Small | None |
+| **P1** | BUG-005 (Row counts) | Small | None |
+| **P1** | BUG-007 (Domain) | Small | None |
+| **P2** | BUG-008 (Classification) | Medium | Depends on BUG-006 |
+| **P3** | BUG-009 (Performance) | Medium | Depends on BUG-004, BUG-005 |
+
+### Key Insight
+
+All high-severity bugs share a common root cause: **the tool relies on procedural data retrieval (describe-table, sample-data) instead of metadata queries (information_schema)**. A unified metadata-first approach would fix BUG-004, BUG-005, and BUG-006 simultaneously.

--- a/docs/mcp-openapi.yaml
+++ b/docs/mcp-openapi.yaml
@@ -240,6 +240,266 @@ paths:
            application/json:
              schema:
                $ref: '#/components/schemas/ErrorResponse'
+  /list-schemas:
+    post:
+      summary: List all accessible database schemas with default schema
+      description: |
+        Returns a list of all schemas accessible to the profile and identifies the default schema.
+        For SQLite, always returns ["main"] with default "main".
+        For PostgreSQL, queries information_schema.schemata.
+        For MySQL/MariaDB, returns databases accessible to the user.
+      operationId: list-schemas
+      tags:
+        - Schema
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListSchemasParams'
+      responses:
+        '200':
+          description: List of schemas with default
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSchemasResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /get-search-path:
+    post:
+      summary: Get the current search_path and effective schema
+      description: |
+        Queries the database to show the current search_path setting and the active schema.
+        Note: This server uses connection pooling. Schema should be explicitly qualified in queries.
+      operationId: get-search-path
+      tags:
+        - Schema
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetSearchPathParams'
+      responses:
+        '200':
+          description: Search path and current schema
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetSearchPathResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /optimize-query:
+    post:
+      summary: Run EXPLAIN and return optimization findings for a SQL statement
+      description: |
+        Analyzes a SQL statement's execution plan and returns optimization findings
+        including missing indexes, inefficient joins, and estimated improvement range.
+      operationId: optimize-query
+      tags:
+        - Query
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OptimizeQueryParams'
+      responses:
+        '200':
+          description: Optimization analysis result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OptimizeQueryResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /validate-query:
+    post:
+      summary: Validate SQL syntax and detect risky patterns without executing
+      description: |
+        Validates SQL syntax and detects risky patterns without executing the statement.
+        Returns validation issues (syntax, logic, security) and pass/fail summary.
+      operationId: validate-query
+      tags:
+        - Query
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidateQueryParams'
+      responses:
+        '200':
+          description: Validation result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidateQueryResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /analyze-data-lineage:
+    post:
+      summary: Trace data dependencies for a table using foreign key relationships
+      description: |
+        Traces upstream and downstream table dependencies using foreign key relationships.
+        Returns dependency graph and edges showing data flow.
+      operationId: analyze-data-lineage
+      tags:
+        - Analysis
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AnalyzeDataLineageParams'
+      responses:
+        '200':
+          description: Lineage analysis result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnalyzeDataLineageResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /discover-insights:
+    post:
+      summary: Discover KPIs, trends, anomalies, and distribution patterns in tables
+      description: |
+        Automatically discovers KPIs, trends, anomalies, and distribution patterns
+        in database tables. Supports filtering by columns and insight types.
+      operationId: discover-insights
+      tags:
+        - Analysis
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DiscoverInsightsParams'
+      responses:
+        '200':
+          description: Discovered insights
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoverInsightsResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /discover-joins:
+    post:
+      summary: Discover joinable relationships between tables and suggest JOIN SQL
+      description: |
+        Discovers foreign key relationships between tables and suggests JOIN SQL statements.
+        Can target specific tables or discover across all tables in the database.
+      operationId: discover-joins
+      tags:
+        - Analysis
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DiscoverJoinsParams'
+      responses:
+        '200':
+          description: Join suggestions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoverJoinsResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /sample-data:
+    post:
+      summary: Fetch sample rows from a table to infer data types and value ranges
+      description: |
+        Fetches sample rows from a table to help AI/agents infer data types, formats,
+        and value ranges. Returns column names and sample values.
+      operationId: sample-data
+      tags:
+        - Data
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SampleDataParams'
+      responses:
+        '200':
+          description: Sample data rows
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SampleDataResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /mcp-info:
+    post:
+      summary: Show MCP provider version and author
+      description: |
+        Returns the MCP provider version, author, and supported capabilities.
+        No parameters required.
+      operationId: mcp-info
+      tags:
+        - Meta
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MCPInfoParams'
+      responses:
+        '200':
+          description: MCP provider info
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MCPInfoResult'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /get-tool-help:
+    post:
+      summary: Get usage help, examples, and common errors for a specific tool
+      description: |
+        Returns detailed help for a specific MCP tool including description,
+        parameters, examples, common errors, and usage notes.
+      operationId: get-tool-help
+      tags:
+        - Meta
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetToolHelpParams'
+      responses:
+        '200':
+          description: Tool help information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetToolHelpResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   schemas:
     ConfigureProfileParams:
@@ -804,18 +1064,653 @@ components:
          type: number
 
     ErrorResponse:
-     type: object
-     properties:
-       status:
-         type: string
-         example: "error"
-       error_code:
-         type: string
-         example: "NO_TABLE_MATCH"
-       message:
-         type: string
-         example: "No table found matching the intent for query generation. Available tables: users, reports, logs."
+      type: object
+      properties:
+        status:
+          type: string
+          example: "error"
+        error_code:
+          type: string
+          example: "NO_TABLE_MATCH"
+        message:
+          type: string
+          example: "No table found matching the intent for query generation. Available tables: users, reports, logs."
+
+    ListSchemasParams:
+      type: object
+      required:
+        - profile_name
+        - database_name
+      properties:
+        profile_name:
+          type: string
+          description: Name of the database profile to use
+        database_name:
+          type: string
+          description: Database name to list schemas for
+
+    ListSchemasResult:
+      type: object
+      properties:
+        schemas:
+          type: array
+          items:
+            type: string
+          description: List of accessible schema names
+        default_schema:
+          type: string
+          description: Default schema name for the database
+
+    GetSearchPathParams:
+      type: object
+      required:
+        - profile_name
+        - database_name
+      properties:
+        profile_name:
+          type: string
+          description: Name of the database profile to use
+        database_name:
+          type: string
+          description: Database name to query search path for
+
+    GetSearchPathResult:
+      type: object
+      properties:
+        search_path:
+          type: string
+          description: Current search_path setting
+        current_schema:
+          type: string
+          description: Effective current schema
+        connection_pooling_warning:
+          type: string
+          description: Warning about connection pooling and schema qualification
+
+    OptimizeQueryParams:
+      type: object
+      required:
+        - profile_name
+        - database_name
+        - sql
+      properties:
+        profile_name:
+          type: string
+          description: Name of the database profile to use
+        database_name:
+          type: string
+          description: Database name to run EXPLAIN against
+        sql:
+          type: string
+          description: SQL statement to optimize
+        params:
+          type: array
+          description: Positional parameters for prepared statements. BLOB/BINARY values must be base64-encoded strings.
+          items:
+            oneOf:
+              - type: string
+              - type: number
+              - type: boolean
+              - type: "null"
+
+    OptimizeQueryResult:
+      type: object
+      properties:
+        plan:
+          $ref: '#/components/schemas/ExplainPlan'
+        findings:
+          type: array
+          items:
+            $ref: '#/components/schemas/OptimizationFinding'
+        estimation:
+          $ref: '#/components/schemas/PerformanceEstimation'
+        summary:
+          type: string
+
+    ExplainPlan:
+      type: object
+      properties:
+        db_type:
+          type: string
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlanStep'
+        raw_json:
+          type: string
+          description: Raw JSON execution plan when available
+        notes:
+          type: array
+          items:
+            type: string
+
+    PlanStep:
+      type: object
+      properties:
+        operation:
+          type: string
+        target:
+          type: string
+        detail:
+          type: string
+        estimated_cost:
+          type: number
+        estimated_rows:
+          type: number
+
+    OptimizationFinding:
+      type: object
+      properties:
+        rule:
+          type: string
+        severity:
+          type: string
+          enum: ["info", "warn", "critical"]
+        message:
+          type: string
+        suggestion:
+          type: string
+
+    PerformanceEstimation:
+      type: object
+      properties:
+        baseline_cost:
+          type: number
+        baseline_rows:
+          type: number
+        confidence:
+          type: number
+        improvement:
+          $ref: '#/components/schemas/ImprovementRange'
+        suggestions:
+          type: array
+          items:
+            type: string
+
+    ImprovementRange:
+      type: object
+      properties:
+        lower_percent:
+          type: number
+        upper_percent:
+          type: number
+        confidence:
+          type: number
+        explanation:
+          type: string
+
+    ValidateQueryParams:
+      type: object
+      required:
+        - profile_name
+        - sql
+      properties:
+        profile_name:
+          type: string
+          description: Name of the database profile to use
+        sql:
+          type: string
+          description: SQL statement to validate
+        database_name:
+          type: string
+          description: Optional database name
+        params:
+          type: array
+          description: Positional parameters for prepared statements (metadata only). BLOB/BINARY values must be base64-encoded strings.
+          items:
+            oneOf:
+              - type: string
+              - type: number
+              - type: boolean
+              - type: "null"
+
+    ValidateQueryResult:
+      type: object
+      properties:
+        is_valid:
+          type: boolean
+        issues:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationIssue'
+        summary:
+          type: string
+        sql:
+          type: string
+        profile_name:
+          type: string
+        database_name:
+          type: string
+
+    ValidationIssue:
+      type: object
+      properties:
+        rule:
+          type: string
+        severity:
+          type: string
+          enum: ["info", "warn", "error"]
+        message:
+          type: string
+        suggestion:
+          type: string
+
+    AnalyzeDataLineageParams:
+      type: object
+      required:
+        - profile_name
+        - table_name
+      properties:
+        profile_name:
+          type: string
+          description: Name of the database profile to use
+        database_name:
+          type: string
+          description: Optional database name override
+        table_name:
+          type: string
+          description: Table to trace lineage for
+        scope:
+          type: string
+          enum: ["upstream", "downstream", "both"]
+          description: Scope of lineage tracing
+        tables:
+          type: array
+          items:
+            type: string
+          description: Specific tables to include
+
+    AnalyzeDataLineageResult:
+      type: object
+      properties:
+        upstream:
+          type: array
+          items:
+            type: string
+          description: Tables upstream from the target
+        downstream:
+          type: array
+          items:
+            type: string
+          description: Tables downstream from the target
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/LineageEdge'
+        summary:
+          type: string
+        scope:
+          type: string
+        target:
+          type: string
+        graph:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+
+    LineageEdge:
+      type: object
+      properties:
+        from_table:
+          type: string
+        to_table:
+          type: string
+        from_column:
+          type: string
+        to_column:
+          type: string
+        constraint:
+          type: string
+
+    DiscoverInsightsParams:
+      type: object
+      required:
+        - profile_name
+        - table_name
+      properties:
+        profile_name:
+          type: string
+          description: Name of the database profile to use
+        table_name:
+          type: string
+          description: Table to discover insights for
+        columns:
+          type: array
+          items:
+            type: string
+          description: Specific columns to analyze (all if empty)
+        insight_types:
+          type: array
+          items:
+            type: string
+            enum: ["kpi", "trend", "anomaly", "distribution"]
+          description: Types of insights to discover
+        max_results:
+          type: integer
+          description: Maximum number of results to return
+
+    DiscoverInsightsResult:
+      type: object
+      properties:
+        table_name:
+          type: string
+        insights:
+          type: array
+          items:
+            $ref: '#/components/schemas/Insight'
+        summary:
+          $ref: '#/components/schemas/InsightsSummary'
+
+    Insight:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: ["kpi", "trend", "anomaly", "distribution"]
+        column:
+          type: string
+        description:
+          type: string
+        kpi:
+          $ref: '#/components/schemas/KPIInsight'
+        trend:
+          $ref: '#/components/schemas/TrendInsight'
+        anomaly:
+          $ref: '#/components/schemas/AnomalyInsight'
+        distribution:
+          $ref: '#/components/schemas/DistributionInsight'
+
+    KPIInsight:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: number
+        unit:
+          type: string
+        benchmark:
+          type: number
+
+    TrendInsight:
+      type: object
+      properties:
+        direction:
+          type: string
+          enum: ["upward", "downward", "stable"]
+        slope:
+          type: number
+        confidence:
+          type: number
+
+    AnomalyInsight:
+      type: object
+      properties:
+        column:
+          type: string
+        expected:
+          type: number
+        actual:
+          type: number
+        severity:
+          type: string
+          enum: ["low", "medium", "high", "critical"]
+
+    DistributionInsight:
+      type: object
+      properties:
+        column:
+          type: string
+        type:
+          type: string
+          enum: ["normal", "uniform", "skewed", "bimodal"]
+        buckets:
+          type: array
+          items:
+            $ref: '#/components/schemas/DistributionBucket'
+        stats:
+          $ref: '#/components/schemas/DistributionStats'
+
+    DistributionBucket:
+      type: object
+      properties:
+        min:
+          type: number
+        max:
+          type: number
+        count:
+          type: integer
+
+    DistributionStats:
+      type: object
+      properties:
+        mean:
+          type: number
+        median:
+          type: number
+        std_dev:
+          type: number
+        skewness:
+          type: number
+        kurtosis:
+          type: number
+
+    InsightsSummary:
+      type: object
+      properties:
+        total_insights:
+          type: integer
+        by_type:
+          type: object
+          additionalProperties:
+            type: integer
+        high_priority:
+          type: integer
+
+    DiscoverJoinsParams:
+      type: object
+      required:
+        - profile_name
+      properties:
+        profile_name:
+          type: string
+          description: Name of the database profile to use
+        tables:
+          type: array
+          items:
+            type: string
+          description: Specific tables to discover joins for (all if empty)
+
+    DiscoverJoinsResult:
+      type: object
+      properties:
+        joins:
+          type: array
+          items:
+            $ref: '#/components/schemas/JoinSuggestion'
+        summary:
+          type: string
+
+    JoinSuggestion:
+      type: object
+      properties:
+        from_table:
+          type: string
+        from_column:
+          type: string
+        to_table:
+          type: string
+        to_column:
+          type: string
+        relationship:
+          type: string
+        suggested_join_sql:
+          type: string
+
+    SampleDataParams:
+      type: object
+      required:
+        - profile_name
+        - database_name
+        - table_name
+      properties:
+        profile_name:
+          type: string
+          description: Name of the database profile to use
+        database_name:
+          type: string
+          description: Database name where the table resides
+        table_name:
+          type: string
+          description: Table to sample data from
+        schema:
+          type: string
+          description: Optional schema name (uses default if empty)
+        sample_size:
+          type: integer
+          description: "Number of sample rows to fetch (default: 3)"
+          default: 3
+
+    SampleDataResult:
+      type: object
+      properties:
+        table_name:
+          type: string
+        sample_size:
+          type: integer
+        columns:
+          type: array
+          items:
+            type: string
+        sample_rows:
+          type: array
+          items:
+            type: array
+            items: {}
+        summary:
+          type: string
+
+    MCPInfoParams:
+      type: object
+      description: Parameters for MCP info (no parameters required)
+      properties: {}
+
+    MCPInfoResult:
+      type: object
+      properties:
+        version:
+          type: string
+          description: MCP provider version
+        author:
+          type: string
+          description: MCP provider author
+        model_info:
+          type: string
+          description: Supported model information
+        tool_count:
+          type: integer
+          description: Number of registered tools
+        capabilities:
+          type: array
+          items:
+            type: string
+          description: List of MCP capabilities
+
+    GetToolHelpParams:
+      type: object
+      required:
+        - tool_name
+      properties:
+        tool_name:
+          type: string
+          description: Name of the tool to get help for
+        topic:
+          type: string
+          description: Optional topic filter (e.g., "parameters", "errors", "all")
+
+    GetToolHelpResult:
+      type: object
+      properties:
+        tool_name:
+          type: string
+        found:
+          type: boolean
+        description:
+          type: string
+        summary:
+          type: string
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolParamInfo'
+        minimal_example:
+          type: object
+          additionalProperties: {}
+        advanced_example:
+          type: object
+          additionalProperties: {}
+        common_errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolHelpError'
+        notes:
+          type: array
+          items:
+            type: string
+        response_format:
+          type: string
+        topics:
+          type: array
+          items:
+            type: string
+
+    ToolParamInfo:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        required:
+          type: boolean
+        description:
+          type: string
+        enum:
+          type: array
+          items:
+            type: string
+        default:
+          type: string
+
+    ToolHelpError:
+      type: object
+      properties:
+        error:
+          type: string
+        cause:
+          type: string
+        fix:
+          type: string
+
+  responses:
+    BadRequest:
+      description: Invalid request parameters
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    InternalServerError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
 # [2025-08-02] CHANGE: describe-table now requires both database_name and table_name as input parameters.
 # The profile's default database is ignored for this operation.
 # [2025-08-04] ADDED: smart-query-builder tool for generating SQL from natural language intent.
 # [2025-08-04] CHANGE: database_name is now a required parameter for execute-sql, list-tables, and sample-data actions.
+# [2026-04-19] ADDED: list-schemas, get-search-path, optimize-query, validate-query, analyze-data-lineage,
+#   discover-insights, discover-joins, sample-data, mcp-info, get-tool-help — all 10 missing tool definitions.
+#   Added components/responses section (BadRequest, InternalServerError) referenced by new paths.

--- a/docs/technical-specifications.md
+++ b/docs/technical-specifications.md
@@ -50,7 +50,7 @@ MCP Client
 
 ## Tool Surface (Implemented)
 
-The server registers these 20 tools:
+The server registers these 21 tools:
 - `configure-profile`
 - `list-profiles`
 - `execute-sql`

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -53,6 +53,7 @@ const (
 	toolDiscoverJoins                   = "discover-joins"
 	toolGetToolHelp                     = "get-tool-help"
 	toolListProfiles                    = "list-profiles"
+	toolListSchemas                     = "list-schemas"
 	mimeTypeApplicationJSON             = "application/json"
 	messageMissingRequiredParameters    = "Missing required parameters"
 	actionProvideAllRequiredParameters  = "Provide all required parameters"
@@ -536,6 +537,20 @@ func (s *MCPServer) registerAllTools() {
 			InputSchema: inputSchemaFor[ListDatabasesParams](),
 		}
 		addTool(s, tool, s.handleListDatabases)
+	}
+
+	// list-schemas
+	{
+		tool := &mcp.Tool{
+			Name: toolListSchemas,
+			Description: descriptionFormatter(`List all accessible database schemas with default schema information.
+  Input: profile_name (required), database_name (required).
+  Returns: list of schema names and the default schema for the database.
+  Example:
+  {"profile_name":"some-profile-name","database_name":"some-database-name"}`),
+			InputSchema: inputSchemaFor[ListSchemasParams](),
+		}
+		addTool(s, tool, s.handleListSchemas)
 	}
 
 	// get-search-path

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3120,7 +3120,7 @@ func resolveDefaultSchema(ctx context.Context, conn *sql.DB, dbType, databaseNam
 	return databaseName
 }
 
-func (s *MCPServer) handleListSchemas(ctx context.Context, _ *mcp.CallToolRequest, input ListSchemasParams) (*mcp.CallToolResult, any, error) { //nolint:unparam // MCP SDK requires 3-return signature
+func (s *MCPServer) handleListSchemas(ctx context.Context, _ *mcp.CallToolRequest, input ListSchemasParams) (*mcp.CallToolResult, any, error) {
 	if input.ProfileName == "" || input.DatabaseName == "" {
 		return nil, nil, fmt.Errorf("profile_name and database_name are required")
 	}

--- a/internal/mcp/tool_help.go
+++ b/internal/mcp/tool_help.go
@@ -181,7 +181,7 @@ var toolHelpCatalog = map[string]toolHelpEntry{
 		ResponseFormat:  "JSON object with databases array of database name strings",
 	},
 	"list-schemas": {
-		Description:     "List all accessible database schemas with default schema information. For SQLite, returns [\"main\"] with default \"main\". For PostgreSQL, queries information_schema.schemata. For MySQL/MariaDB, returns databases accessible to the user.",
+		Description: "List all accessible database schemas with default schema information. For SQLite, returns [\"main\"] with default \"main\". For PostgreSQL, queries information_schema.schemata. For MySQL/MariaDB, returns databases accessible to the user.",
 		Parameters: []ToolParamInfo{
 			paramProfile,
 			paramDBRequired,

--- a/internal/mcp/tool_help.go
+++ b/internal/mcp/tool_help.go
@@ -180,6 +180,21 @@ var toolHelpCatalog = map[string]toolHelpEntry{
 		CommonErrors:    []ToolHelpError{errProfileNotFound},
 		ResponseFormat:  "JSON object with databases array of database name strings",
 	},
+	"list-schemas": {
+		Description:     "List all accessible database schemas with default schema information. For SQLite, returns [\"main\"] with default \"main\". For PostgreSQL, queries information_schema.schemata. For MySQL/MariaDB, returns databases accessible to the user.",
+		Parameters: []ToolParamInfo{
+			paramProfile,
+			paramDBRequired,
+		},
+		Summary:         "List accessible schemas and identify the default schema.",
+		MinimalExample:  map[string]any{"profile_name": "analytics_db", "database_name": "analytics_db"},
+		AdvancedExample: map[string]any{"profile_name": "analytics_db", "database_name": "analytics_db"},
+		CommonErrors: []ToolHelpError{
+			errProfileNotFound,
+			{Error: "Database not found", Cause: "database_name does not exist on the server", Fix: "Use list-databases to see available databases"},
+		},
+		ResponseFormat: "JSON object with schemas array and default_schema string",
+	},
 	"analyze-schema": {
 		Description: "Analyze database schema metadata at selectable depth. Returns table catalogs, column details, relationships, data quality metrics, and AI query suggestions based on analysis level.",
 		Parameters: []ToolParamInfo{


### PR DESCRIPTION
## Summary

Fixes #85 and #87 — two related issues affecting tool discoverability and API documentation completeness.

### Issue #87 — `list-schemas` tool not registered
- The `handleListSchemas` handler, `ListSchemasParams`, and `ListSchemasResult` types existed but the tool was never registered via `addTool()`, making it invisible to MCP clients.
- **Fix**: Added `toolListSchemas` constant, `addTool()` registration block, and `list-schemas` help entry.

### Issue #85 — OpenAPI spec missing 9 of 20 tool definitions
- Only 11 of 20 registered tools had endpoint definitions in `docs/mcp-openapi.yaml`.
- **Fix**: Added 10 path definitions (9 previously missing + list-schemas) and all corresponding component schemas.

### Tool count: 20 → 21
Updated in README.md, technical-specifications.md, and memory-bank docs.

## Changes

- `internal/mcp/server.go` — Added `toolListSchemas` constant and `addTool()` registration
- `internal/mcp/tool_help.go` — Added `list-schemas` help entry
- `docs/mcp-openapi.yaml` — Added 10 missing path definitions + component schemas (ExplainPlan, PlanStep, OptimizationFinding, PerformanceEstimation, ImprovementRange, ValidationIssue, LineageEdge, Insight variants, JoinSuggestion, SampleData, MCPInfo, GetToolHelp, BadRequest, InternalServerError)
- `README.md`, `docs/technical-specifications.md`, `.kilocode/rules/memory-bank/*.md` — Updated tool count 20→21

## Test Commands

```bash
go build -o ./tmp/mcp-server ./cmd/server/main.go
go vet ./...
go test ./...
```

All tests pass, including `TestToolHelpCatalog_CoversAllRegisteredTools`, `TestAllRegisteredToolsHaveInputSchema`, and `TestToolsList_Discovery`.