### PR TITLE
chore: bump version to v1.6.0

### DIFF
--- a/.kilocode/rules/memory-bank/architecture.md
+++ b/.kilocode/rules/memory-bank/architecture.md
@@ -50,7 +50,7 @@ MCP Client
   - shared helper functions
 
 ### Analyze Package (`internal/mcp/analyze`)
-- `analyzer.go` — Run() orchestration, table schema building, relationship graph, classification signals
+- `analyzer.go` — Run() orchestration, table schema building, FK/index enrichment pipeline, relationship graph, classification signals
 - `columns.go` — Bulk column fetching with parameterized queries (TVF for SQLite)
 - `relationships.go` — Real FK discovery, implicit relationships, relationship graph building
 - `performance.go` — Index analysis, performance optimization recommendations
@@ -86,13 +86,13 @@ MCP Client
 
 ## Runtime Contracts
 
-### Registered Tools (20)
+### Registered Tools (21)
 - `configure-profile`, `list-profiles`, `execute-sql`
 - `list-tables`, `describe-table`, `list-databases`, `get-search-path`
 - `analyze-schema`, `smart-query-builder`, `discover-joins`, `sample-data`
 - `optimize-query`, `validate-query`, `analyze-data-lineage`, `discover-insights`
 - `track-schema-changes`, `federated-query`
-- `mcp-info`, `list-tools`, `get-tool-help`
+- `list-tools`, `get-tool-help`, `mcp-info`, `list-schemas`
 
 ### Resources
 - `tools://list` (registered tools snapshot)

--- a/.kilocode/rules/memory-bank/brief.md
+++ b/.kilocode/rules/memory-bank/brief.md
@@ -5,8 +5,8 @@
 Database MCP Server is a production-ready MCP provider for SQL databases, implemented in Go. It exposes a unified tool interface so AI agents and developers can safely interact with MySQL, MariaDB, PostgreSQL, and SQLite.
 
 Current implementation state:
-- Version: `v1.5.1`
-- MCP tools: `20` implemented and registered
+- Version: `v1.6.0`
+- MCP tools: `21` implemented and registered
 - Packaging: GitHub Releases + GHCR container images
 
 ## Core Mission

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -2,11 +2,11 @@
 
 ## Current State
 
-- Version: `v1.5.1`
+- Version: `v1.6.0`
 - Stage: Production-ready
 - Toolchain: `go 1.26` with `go1.26.2`
 - MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.5.0`
-- Registered tools: `20`
+- Registered tools: `21`
 
 ## Implemented Capabilities
 
@@ -46,12 +46,13 @@ Server.go has a thin handler that delegates to `analyze.Run()`, keeping only MCP
 - `internal/mcp/nlp/` — Entity extractor and intent classifier for smart-query-builder
 - `internal/mcp/context/` — Conversation context manager
 
-### Key Refactoring (v1.4.0–v1.5.1)
+### Key Refactoring (v1.4.0–v1.6.0)
 - Extracted ~40 functions from server.go into `internal/mcp/analyze/` as pure functions
 - Fixed MySQL/MariaDB schema resolution bug (#75–#80): `resolveSchemaForAnalyze` now passes `databaseName` instead of empty string
 - Added `Warnings []string` to `AnalyzeSchemaResult` for privilege detection
 - Security hardening: all `fmt.Sprintf` SQL eliminated, SQLite PRAGMAs converted to parameterized TVF, `sanitizeIdentifier()` + `quoteForDB()` added
 - Extracted 8 helper functions for cognitive complexity reduction (SonarCloud S3776)
+- **v1.6.0**: Signal-provider architecture — replaced hardcoded domain/entity classification with raw naming prefix frequencies + FK structural analysis. Fixed FK/index data pipeline (applyFKsToColumns, applyFKsToSchemas, applyIndexesToColumns, rebuildKeyColumns). Reduced cognitive complexity in CategorizeTables and BuildPerformanceOptimization.
 
 ## Gemini Compatibility
 
@@ -63,11 +64,11 @@ Server.go has a thin handler that delegates to `analyze.Run()`, keeping only MCP
 
 - Release workflow publishes GitHub Releases from tags
 - Package workflow publishes GHCR container images
-- Latest release line currently aligned at `v1.5.1`
+- Latest release line currently aligned at `v1.6.0`
 
 ## Documentation State
 
-- Root README aligned with `v1.5.1` and 21 tools
+- Root README aligned with `v1.6.0` and 21 tools
 - docs/ updated to reflect current runtime behavior
 - Wiki expanded with onboarding, tool-scenario mapping, and client setup guides
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.6.0] - 2026-04-19
+
+### Added
+
+- **FK/index data pipeline fix** (Issues #77, #80): Discovered foreign keys and indexes now flow correctly into `table_schemas[].key_columns` output.
+  - New `applyFKsToColumns()` — sets `IsForeignKey=true` and `ForeignKeyRef` on FK columns in `SchemaColumnInfo`.
+  - New `applyFKsToSchemas()` — populates `KeyColumns.ForeignKeys` from discovered FK relationships.
+  - New `applyIndexesToColumns()` — sets `Indexed=true` on columns present in fetched indexes (including composite indexes missed by column metadata queries).
+  - New `rebuildKeyColumns()` — re-extracts `KeyColumns` from enriched column data after all apply functions run.
+- 6 regression tests for FK/index data pipeline (empty-input safety, PK index skip, end-to-end integration).
+
 ### Changed
 
 - **Signal-provider architecture for `analyze-schema`** (Issues #77-#80): The MCP server now provides raw structured signals for the calling LLM to interpret, rather than making hardcoded domain/entity/performance classifications.
@@ -11,13 +22,19 @@ All notable changes to this project will be documented in this file.
   - **Issue #78**: Replaced hardcoded 7-domain `DetectDomain` with signal-based `ComputeDomainSignals` that produces naming prefix frequencies (e.g., `{"call": 5, "broadcast": 3, "sip": 2}`). The calling LLM interprets domain from raw signals using its own world knowledge. Updated tool description to inform LLMs that `domain_indicators` provides signal frequencies, not authoritative labels.
   - **Issue #79**: Enhanced `CategorizeTables` with FK structural analysis: tables with 2+ outgoing FKs and few non-FK columns are classified as junction tables. Added `OutgoingFKs`/`IncomingFKs` signal fields to `TableEntity`.
   - **Issue #80**: Added `IndexCoverage` struct to `PerformanceOptimization` reporting total/indexed/unindexed FK columns and tables without primary keys. Added tables-without-PK detection.
+- **Cognitive complexity reduction** (SonarCloud go:S3776):
+  - Extracted `classifyTable`, `buildFKSignalMaps`, `isAuditTable`, `isJunctionTable`, `isLookupTable` from `CategorizeTables` (complexity 17 → ~5).
+  - Extracted `buildIndexedColSet`, `recommendFKIndexes`, `findTablesWithoutPK` from `BuildPerformanceOptimization` (complexity 24 → ~5).
 
 ### Removed
 
 - Removed legacy dead code from `server.go`: `detectImplicitRelationships`, `analyzeNamingRelationships`, `correlateDataValues`, `referenceColumnsForTarget`, `buildIDSet`, `countReferenceMatches` (only used by coverage tests, never by handlers).
 - Removed `mergeDomainIndicators` helper (replaced by `ComputeDomainSignals`).
 
-### Added
+### Fixed
+
+- **PR #88** (Issues #85, #87): Fixed OpenAPI spec missing 10 tool definitions and `list-schemas` tool not registered. Tool count: 20 → 21 across all docs.
+- Marked unused parameters in `GenerateBusinessDescription` with `_` (kilo-code-bot review).
 
 ## [v1.5.1] - 2026-04-19
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go](https://img.shields.io/badge/Go-1.26.0%2B-00ADD8?logo=Go&logoColor=white)](https://go.dev)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-v1.5.1-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.5.1)
+[![Version](https://img.shields.io/badge/Version-v1.6.0-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.6.0)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
@@ -28,10 +28,10 @@ go build -o mcp-server ./cmd/server/main.go
 
 ```bash
 # Pull the release image
-docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.5.1
+docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.6.0
 
 # Run with stdio transport
-docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.5.1
+docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.6.0
 ```
 
 ```bash
@@ -39,7 +39,7 @@ docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.5.1
 mkdir -p ./.mcp-data
 docker run --rm -i \
   -v "$(pwd)/.mcp-data:/app" \
-  ghcr.io/guyinwonder168/database-mcp-server:v1.5.1
+  ghcr.io/guyinwonder168/database-mcp-server:v1.6.0
 ```
 
 Package registry: `https://github.com/guyinwonder168/database-mcp-server/pkgs/container/database-mcp-server`
@@ -190,7 +190,7 @@ go test ./internal/mcp -run "TestLoadLineage" -v  # Lineage edge tests
 
 ## 📊 Project Status
 
-- **Version:** v1.5.1
+- **Version:** v1.6.0
 - **Built with:** Various vibe coding tools
 - **Status:** Production Ready ✅
 - All 21 MCP tools are fully implemented and OpenAPI-aligned.

--- a/docs/mcp-openapi.yaml
+++ b/docs/mcp-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Database MCP Provider API
-  version: "1.5.1"
+  version: "1.6.0"
   description: |
     OpenAPI documentation for all MCP tools exposed by the Database MCP Provider.
     This enables LLMs and clients to discover and use all available actions programmatically.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -43,7 +43,7 @@ type MCPServer struct {
 	contextMgr    *ctxmgr.Manager
 }
 
-const MCPVersion = "v1.5.1"
+const MCPVersion = "v1.6.0"
 const MCPAuthor = "guyinwonder"
 
 const sqliteListTablesQuery = "SELECT name FROM sqlite_master WHERE type='table'"


### PR DESCRIPTION
## Summary
- Bump `MCPVersion` from `v1.5.1` to `v1.6.0` in `internal/mcp/server.go`
- Sync version references in `README.md` and `docs/mcp-openapi.yaml` via sync script
- Update `CHANGELOG.md` with v1.6.0 release notes covering PRs #88 and #89
- Update `.kilocode/rules/memory-bank/` files (brief, context, architecture) to reflect v1.6.0

## Changes Since v1.5.1
- **PR #88**: Fixed OpenAPI spec missing 10 tool definitions and `list-schemas` tool registration (Issues #85, #87)
- **PR #89**: Signal-provider architecture for `analyze-schema` — FK/index data pipeline fix, cognitive complexity reduction, dead code removal (Issues #77-#80)

## Version Sync Checklist
- [x] `internal/mcp/server.go` `MCPVersion` updated
- [x] `scripts/sync-version-from-server.sh` run
- [x] `CHANGELOG.md` section header matches `v1.6.0`
- [x] `.kilocode/` memory bank updated