### PR TITLE
fix: update mcp-info tool count from 20 to 21

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -924,7 +924,7 @@ func (s *MCPServer) handleMCPInfo(ctx context.Context, _ *mcp.CallToolRequest, i
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			&mcp.TextContent{
-				Text: "Database MCP Provider\nAuthor: " + MCPAuthor + "\nVersion: " + MCPVersion + "\nBuilt via OpenAgent framework with multiple AI models (Claude, GLM, GPT, etc.).\nFeatures: 20 tools (including profile delete/clone), optimized for strict declaration budgets.",
+				Text: "Database MCP Provider\nAuthor: " + MCPAuthor + "\nVersion: " + MCPVersion + "\nBuilt via OpenAgent framework with multiple AI models (Claude, GLM, GPT, etc.).\nFeatures: 21 tools (including profile delete/clone), optimized for strict declaration budgets.",
 			},
 		},
 	}, nil, nil


### PR DESCRIPTION
## Summary
- Fix hardcoded tool count in `mcp-info` response from "20 tools" to "21 tools"
- `list-schemas` was added in PR #88 but the `mcp-info` Features string was never updated

## Test
- `mcp-info` now reports `Features: 21 tools` matching the actual registered tool count