### PR TITLE
chore: bump version to v1.6.1

### DIFF
--- a/.kilocode/rules/memory-bank/brief.md
+++ b/.kilocode/rules/memory-bank/brief.md
@@ -5,7 +5,7 @@
 Database MCP Server is a production-ready MCP provider for SQL databases, implemented in Go. It exposes a unified tool interface so AI agents and developers can safely interact with MySQL, MariaDB, PostgreSQL, and SQLite.
 
 Current implementation state:
-- Version: `v1.6.0`
+- Version: `v1.6.1`
 - MCP tools: `21` implemented and registered
 - Packaging: GitHub Releases + GHCR container images
 

--- a/.kilocode/rules/memory-bank/context.md
+++ b/.kilocode/rules/memory-bank/context.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- Version: `v1.6.0`
+- Version: `v1.6.1`
 - Stage: Production-ready
 - Toolchain: `go 1.26` with `go1.26.2`
 - MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.5.0`
@@ -64,11 +64,11 @@ Server.go has a thin handler that delegates to `analyze.Run()`, keeping only MCP
 
 - Release workflow publishes GitHub Releases from tags
 - Package workflow publishes GHCR container images
-- Latest release line currently aligned at `v1.6.0`
+- Latest release line currently aligned at `v1.6.1`
 
 ## Documentation State
 
-- Root README aligned with `v1.6.0` and 21 tools
+- Root README aligned with `v1.6.1` and 21 tools
 - docs/ updated to reflect current runtime behavior
 - Wiki expanded with onboarding, tool-scenario mapping, and client setup guides
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.6.1] - 2026-04-19
+
+### Fixed
+
+- Updated `mcp-info` tool count from "20 tools" to "21 tools" to reflect the `list-schemas` tool added in PR #88.
+
 ## [v1.6.0] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go](https://img.shields.io/badge/Go-1.26.0%2B-00ADD8?logo=Go&logoColor=white)](https://go.dev)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-v1.6.0-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.6.0)
+[![Version](https://img.shields.io/badge/Version-v1.6.1-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.6.1)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
@@ -28,10 +28,10 @@ go build -o mcp-server ./cmd/server/main.go
 
 ```bash
 # Pull the release image
-docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.6.0
+docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.6.1
 
 # Run with stdio transport
-docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.6.0
+docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.6.1
 ```
 
 ```bash
@@ -39,7 +39,7 @@ docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.6.0
 mkdir -p ./.mcp-data
 docker run --rm -i \
   -v "$(pwd)/.mcp-data:/app" \
-  ghcr.io/guyinwonder168/database-mcp-server:v1.6.0
+  ghcr.io/guyinwonder168/database-mcp-server:v1.6.1
 ```
 
 Package registry: `https://github.com/guyinwonder168/database-mcp-server/pkgs/container/database-mcp-server`
@@ -190,7 +190,7 @@ go test ./internal/mcp -run "TestLoadLineage" -v  # Lineage edge tests
 
 ## 📊 Project Status
 
-- **Version:** v1.6.0
+- **Version:** v1.6.1
 - **Built with:** Various vibe coding tools
 - **Status:** Production Ready ✅
 - All 21 MCP tools are fully implemented and OpenAPI-aligned.

--- a/docs/mcp-openapi.yaml
+++ b/docs/mcp-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Database MCP Provider API
-  version: "1.6.0"
+  version: "1.6.1"
   description: |
     OpenAPI documentation for all MCP tools exposed by the Database MCP Provider.
     This enables LLMs and clients to discover and use all available actions programmatically.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -43,7 +43,7 @@ type MCPServer struct {
 	contextMgr    *ctxmgr.Manager
 }
 
-const MCPVersion = "v1.6.0"
+const MCPVersion = "v1.6.1"
 const MCPAuthor = "guyinwonder"
 
 const sqliteListTablesQuery = "SELECT name FROM sqlite_master WHERE type='table'"


### PR DESCRIPTION
## Summary
- Bump `MCPVersion` from `v1.6.0` to `v1.6.1`
- Sync README.md and docs/mcp-openapi.yaml via sync script
- Update CHANGELOG.md with v1.6.1 release notes (mcp-info tool count fix)
- Update .kilocode memory-bank files

## Changes Since v1.6.0
- **PR #91**: Fixed `mcp-info` tool count from "20 tools" to "21 tools"

## Version Sync Checklist
- [x] `internal/mcp/server.go` `MCPVersion` updated
- [x] `scripts/sync-version-from-server.sh` run
- [x] `CHANGELOG.md` section header matches `v1.6.1`
- [x] `.kilocode/` memory bank updated