### PR TITLE
chore: bump version to v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.6.2] - 2026-04-19
+
+### Fixed
+
+- **Code scanning alerts (gosec)**: Resolved 4 open security alerts:
+  - **G115**: Replaced `byte(unicode.ToLower(rune(ch)))` with explicit `A-Z` range check in `sanitizeReadOnlySQL` — only converts uppercase ASCII letters, leaving all other characters (`_`, `@`, `[`, etc.) untouched
+  - **G201**: Added proper identifier validation and dialect-specific quoting in `sampleTableData` via new `sanitizeSQLIdentifier()` regex validator and `safeQuoteIdentifier()` function
+  - **G117**: Added `#nosec G117` with justification — Password field is redacted to `""` before JSON marshaling
+  - **G602**: Added `#nosec G602` with justification — `bucketIndex` is bounded to `[0,9]` by explicit range checks
+- Added 29 new test cases covering identifier validation, dialect-specific quoting, and SQL injection rejection
+- All 18 CI checks passing: gosec, SonarCloud, lint, coverage (85.9%), CodeQL, security
+
 ## [v1.6.1] - 2026-04-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go](https://img.shields.io/badge/Go-1.26.0%2B-00ADD8?logo=Go&logoColor=white)](https://go.dev)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-v1.6.1-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.6.1)
+[![Version](https://img.shields.io/badge/Version-v1.6.2-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.6.2)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
@@ -28,10 +28,10 @@ go build -o mcp-server ./cmd/server/main.go
 
 ```bash
 # Pull the release image
-docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.6.1
+docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.6.2
 
 # Run with stdio transport
-docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.6.1
+docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.6.2
 ```
 
 ```bash
@@ -39,7 +39,7 @@ docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.6.1
 mkdir -p ./.mcp-data
 docker run --rm -i \
   -v "$(pwd)/.mcp-data:/app" \
-  ghcr.io/guyinwonder168/database-mcp-server:v1.6.1
+  ghcr.io/guyinwonder168/database-mcp-server:v1.6.2
 ```
 
 Package registry: `https://github.com/guyinwonder168/database-mcp-server/pkgs/container/database-mcp-server`
@@ -190,7 +190,7 @@ go test ./internal/mcp -run "TestLoadLineage" -v  # Lineage edge tests
 
 ## 📊 Project Status
 
-- **Version:** v1.6.1
+- **Version:** v1.6.2
 - **Built with:** Various vibe coding tools
 - **Status:** Production Ready ✅
 - All 21 MCP tools are fully implemented and OpenAPI-aligned.

--- a/docs/mcp-openapi.yaml
+++ b/docs/mcp-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Database MCP Provider API
-  version: "1.6.1"
+  version: "1.6.2"
   description: |
     OpenAPI documentation for all MCP tools exposed by the Database MCP Provider.
     This enables LLMs and clients to discover and use all available actions programmatically.

--- a/docs/technical-specifications.md
+++ b/docs/technical-specifications.md
@@ -5,8 +5,8 @@
 Database MCP Server is a production MCP provider for SQL databases, built in Go.
 
 Current implementation baseline:
-- Runtime version: `v1.5.1`
-- Registered tools: `20`
+- Runtime version: `v1.6.2`
+- Registered tools: `21`
 - Go module baseline: `go 1.26` (`toolchain go1.26.1`)
 - MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.2.0`
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -42,7 +42,7 @@ type MCPServer struct {
 	contextMgr    *ctxmgr.Manager
 }
 
-const MCPVersion = "v1.6.1"
+const MCPVersion = "v1.6.2"
 const MCPAuthor = "guyinwonder"
 
 const sqliteListTablesQuery = "SELECT name FROM sqlite_master WHERE type='table'"


### PR DESCRIPTION
## Summary
- Bump version from v1.6.1 → v1.6.2
- Incorporates PR #93 fixes (code scanning alerts, SQL injection prevention, identifier validation)

## Changes
- `internal/mcp/server.go`: `MCPVersion = "v1.6.2"`
- `README.md`: version badge, container image tags, project status
- `CHANGELOG.md`: added v1.6.2 release notes
- `docs/technical-specifications.md`: runtime version, tool count
- Wiki: updated version refs across all pages (Home, Client-Setup-Guides, Installation, Troubleshooting, References)

## Next Steps
- Merge this PR
- Tag release: `git tag v1.6.2 && git push origin v1.6.2`