### PR TITLE
fix: preserve execute-sql database error diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed `execute-sql` discarding direct query errors and returning `UNKNOWN_ERROR` with `details: "<nil>"`. Database driver details are now preserved, and MySQL/MariaDB unknown-column errors map to `COLUMN_NOT_FOUND`.
+- Fixed `execute-sql` discarding direct and row-stream query errors and returning `UNKNOWN_ERROR` with `details: "<nil>"`. SQL driver details are now preserved, MySQL/MariaDB errno and SQLSTATE metadata are exposed, and unknown-column errors map to `COLUMN_NOT_FOUND`.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `execute-sql` discarding direct query errors and returning `UNKNOWN_ERROR` with `details: "<nil>"`. Database driver details are now preserved, and MySQL/MariaDB unknown-column errors map to `COLUMN_NOT_FOUND`.
+
 ### Security
 
 - Updated the Go toolchain and CI/Docker build images from vulnerable patch releases to Go 1.26.4, resolving reachable standard-library findings reported by `govulncheck`.

--- a/docs/mcp-examples.md
+++ b/docs/mcp-examples.md
@@ -79,12 +79,14 @@ When a query fails (e.g., referencing a missing table), the MCP server returns a
   "context": {
     "profile_name": "mydb",
     "table_name": "",
-    "column_name": "u.email"
+    "column_name": "u.email",
+    "database_error_code": 1054,
+    "sql_state": "42S22"
   }
 }
 ```
 
-The `details` field preserves the database driver's diagnostic text, including vendor error numbers and SQLSTATE values when available. Bound parameter values and credentials are not included in the structured response.
+For SQL execution failures, the `details` field preserves the database driver's diagnostic text. Typed MySQL/MariaDB errors also expose `database_error_code` and `sql_state` in `context`. The server does not append bound parameters or credentials to the response, and known MySQL duplicate-key values are redacted from driver text.
 
 #### SQL Syntax Error
 

--- a/docs/mcp-examples.md
+++ b/docs/mcp-examples.md
@@ -63,8 +63,8 @@ When a query fails (e.g., referencing a missing table), the MCP server returns a
 {
   "status": "error",
   "error_code": "COLUMN_NOT_FOUND",
-  "message": "Column 'email' not found in table 'users'",
-  "details": "The specified column does not exist in the table",
+  "message": "Column 'u.email' not found",
+  "details": "Error 1054 (42S22): Unknown column 'u.email' in 'field list'",
   "suggestions": [
     {
       "action": "Describe table schema",
@@ -78,11 +78,13 @@ When a query fails (e.g., referencing a missing table), the MCP server returns a
   ],
   "context": {
     "profile_name": "mydb",
-    "table_name": "users",
-    "column_name": "email"
+    "table_name": "",
+    "column_name": "u.email"
   }
 }
 ```
+
+The `details` field preserves the database driver's diagnostic text, including vendor error numbers and SQLSTATE values when available. Bound parameter values and credentials are not included in the structured response.
 
 #### SQL Syntax Error
 

--- a/docs/testing/issue-116.tdd.md
+++ b/docs/testing/issue-116.tdd.md
@@ -14,6 +14,8 @@ As an MCP client diagnosing a failed SQL query, I want the database driver's err
 |---|---|
 | RED | `go test ./internal/mcp -run TestQueryRowsForSQLPreservesMySQLUnknownColumnError -count=1` failed because `queryRowsForSQL` returned a nil MCP error result after MySQL error 1054. |
 | GREEN | The same focused command passed after direct query errors were analyzed and returned as structured MCP errors. |
+| Review RED | The typed-driver and row-stream regression command failed because errno/SQLSTATE metadata was absent and `rows.Err()` was ignored. |
+| Review GREEN | `go test ./internal/mcp -run 'Test(QueryRowsForSQLPreservesMySQLUnknownColumnError\|TryExecuteSQLQueryPreservesRowIterationError)$' -count=1` passed after metadata extraction and row-stream error handling were added. |
 | Regression | `go test ./internal/mcp -count=1` passed after the implementation and response-message refinement. |
 
 ## Test specification
@@ -23,14 +25,26 @@ As an MCP client diagnosing a failed SQL query, I want the database driver's err
 | 1 | A direct MySQL query failure returns an MCP error result rather than falling through to statement execution. | `TestQueryRowsForSQLPreservesMySQLUnknownColumnError` | Integration-style unit test with `sqlmock` | PASS |
 | 2 | MySQL error 1054 maps to `COLUMN_NOT_FOUND`. | `TestQueryRowsForSQLPreservesMySQLUnknownColumnError` | Error contract | PASS |
 | 3 | Driver errno, SQLSTATE, and message are preserved in `details`; `"<nil>"` is never emitted. | `TestQueryRowsForSQLPreservesMySQLUnknownColumnError` | Regression | PASS |
+| 4 | A delayed row iteration failure returns `SQL_EXECUTION_ERROR` instead of partial rows. | `TestTryExecuteSQLQueryPreservesRowIterationError` | Regression | PASS |
+| 5 | Non-SQL connection diagnostics do not expose raw connection details. | `TestAnalyzeErrorDoesNotExposeNonSQLConnectionDetails` | Security regression | PASS |
+| 6 | MySQL duplicate-key diagnostics preserve error metadata while redacting the conflicting value. | `TestAnalyzeErrorRedactsMySQLDuplicateEntryValue` | Security regression | PASS |
 
 ## Security boundary
 
-The structured response includes the database driver's error text and query metadata already used by the error analyzer. It does not add bound parameter values, credentials, or connection strings to the response.
+The structured response includes the database driver's error text only for SQL execution operations. MySQL duplicate-entry values are redacted, including values containing apostrophes. The server does not append bound parameters, credentials, or connection strings to the response.
 
 ## Coverage and known gaps
 
 The regression uses a deterministic MySQL-compatible driver error through `sqlmock`. Live MariaDB verification remains covered by the repository's optional integration-test workflow rather than this unit test.
+
+## Final verification
+
+- `go test ./...` — PASS
+- `go vet ./...` — PASS
+- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./... --timeout=5m` — PASS, 0 issues
+- `go test -cover ./...` — PASS; `internal/mcp` coverage 86.0%
+- `go build -o ./tmp/mcp-server ./cmd/server/main.go` — PASS
+- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` — PASS, no called vulnerabilities
 
 ## Checkpoints
 

--- a/docs/testing/issue-116.tdd.md
+++ b/docs/testing/issue-116.tdd.md
@@ -1,0 +1,38 @@
+# Issue #116 TDD Evidence
+
+## Source
+
+Journeys and acceptance criteria were derived from GitHub issue #116.
+
+## User journey
+
+As an MCP client diagnosing a failed SQL query, I want the database driver's error details and a stable error code so that I can correct the query without switching to a database CLI.
+
+## Task report
+
+| Stage | Evidence |
+|---|---|
+| RED | `go test ./internal/mcp -run TestQueryRowsForSQLPreservesMySQLUnknownColumnError -count=1` failed because `queryRowsForSQL` returned a nil MCP error result after MySQL error 1054. |
+| GREEN | The same focused command passed after direct query errors were analyzed and returned as structured MCP errors. |
+| Regression | `go test ./internal/mcp -count=1` passed after the implementation and response-message refinement. |
+
+## Test specification
+
+| # | Guarantee | Test | Type | Result |
+|---|---|---|---|---|
+| 1 | A direct MySQL query failure returns an MCP error result rather than falling through to statement execution. | `TestQueryRowsForSQLPreservesMySQLUnknownColumnError` | Integration-style unit test with `sqlmock` | PASS |
+| 2 | MySQL error 1054 maps to `COLUMN_NOT_FOUND`. | `TestQueryRowsForSQLPreservesMySQLUnknownColumnError` | Error contract | PASS |
+| 3 | Driver errno, SQLSTATE, and message are preserved in `details`; `"<nil>"` is never emitted. | `TestQueryRowsForSQLPreservesMySQLUnknownColumnError` | Regression | PASS |
+
+## Security boundary
+
+The structured response includes the database driver's error text and query metadata already used by the error analyzer. It does not add bound parameter values, credentials, or connection strings to the response.
+
+## Coverage and known gaps
+
+The regression uses a deterministic MySQL-compatible driver error through `sqlmock`. Live MariaDB verification remains covered by the repository's optional integration-test workflow rather than this unit test.
+
+## Checkpoints
+
+- RED: `97b958f test: reproduce masked execute-sql database error`
+- GREEN: `ef1e2b0 fix: preserve execute-sql database errors`

--- a/docs/testing/issue-116.tdd.md
+++ b/docs/testing/issue-116.tdd.md
@@ -36,3 +36,4 @@ The regression uses a deterministic MySQL-compatible driver error through `sqlmo
 
 - RED: `97b958f test: reproduce masked execute-sql database error`
 - GREEN: `ef1e2b0 fix: preserve execute-sql database errors`
+- Refactor: `568e330 refactor: refine execute-sql error response`

--- a/docs/testing/issue-116.tdd.md
+++ b/docs/testing/issue-116.tdd.md
@@ -18,6 +18,8 @@ As an MCP client diagnosing a failed SQL query, I want the database driver's err
 | Review GREEN | `go test ./internal/mcp -run 'Test(QueryRowsForSQLPreservesMySQLUnknownColumnError\|TryExecuteSQLQueryPreservesRowIterationError)$' -count=1` passed after metadata extraction and row-stream error handling were added. |
 | Sonar RED | SonarCloud rule `go:S3776` reported cognitive complexity 19 in `AnalyzeError`, above the allowed 15. |
 | Sonar GREEN | MySQL numeric-code and message-based classification were extracted into focused helpers; all characterization tests remained green. |
+| P2 Review RED | `go test ./internal/mcp -run 'TestAnalyzeError(ExtractsQualifiedMySQLTableName\|PreservesDatabaseNameForMySQL1049)$' -count=1` failed with `Table '' not found` and `Database '' not found`. |
+| P2 Review GREEN | The same focused command passed after qualified table names were parsed from MySQL 1146 errors and MySQL 1049 reused the existing `database` context as `database_name`. |
 | Regression | `go test ./internal/mcp -count=1` passed after the implementation and response-message refinement. |
 
 ## Test specification
@@ -30,6 +32,8 @@ As an MCP client diagnosing a failed SQL query, I want the database driver's err
 | 4 | A delayed row iteration failure returns `SQL_EXECUTION_ERROR` instead of partial rows. | `TestTryExecuteSQLQueryPreservesRowIterationError` | Regression | PASS |
 | 5 | Non-SQL connection diagnostics do not expose raw connection details. | `TestAnalyzeErrorDoesNotExposeNonSQLConnectionDetails` | Security regression | PASS |
 | 6 | MySQL duplicate-key diagnostics preserve error metadata while redacting the conflicting value. | `TestAnalyzeErrorRedactsMySQLDuplicateEntryValue` | Security regression | PASS |
+| 7 | MySQL 1146 errors preserve schema-qualified table names such as `hrm.ohrm_user`. | `TestAnalyzeErrorExtractsQualifiedMySQLTableName` | Review regression | PASS |
+| 8 | MySQL 1049 errors map `database` context to `database_name` without exposing raw non-SQL connection details. | `TestAnalyzeErrorPreservesDatabaseNameForMySQL1049` | Review regression | PASS |
 
 ## Security boundary
 
@@ -53,3 +57,4 @@ The regression uses a deterministic MySQL-compatible driver error through `sqlmo
 - RED: `97b958f test: reproduce masked execute-sql database error`
 - GREEN: `ef1e2b0 fix: preserve execute-sql database errors`
 - Refactor: `568e330 refactor: refine execute-sql error response`
+- P2 review RED: `af18e8f test: reproduce MySQL error context review findings`

--- a/docs/testing/issue-116.tdd.md
+++ b/docs/testing/issue-116.tdd.md
@@ -16,6 +16,8 @@ As an MCP client diagnosing a failed SQL query, I want the database driver's err
 | GREEN | The same focused command passed after direct query errors were analyzed and returned as structured MCP errors. |
 | Review RED | The typed-driver and row-stream regression command failed because errno/SQLSTATE metadata was absent and `rows.Err()` was ignored. |
 | Review GREEN | `go test ./internal/mcp -run 'Test(QueryRowsForSQLPreservesMySQLUnknownColumnError\|TryExecuteSQLQueryPreservesRowIterationError)$' -count=1` passed after metadata extraction and row-stream error handling were added. |
+| Sonar RED | SonarCloud rule `go:S3776` reported cognitive complexity 19 in `AnalyzeError`, above the allowed 15. |
+| Sonar GREEN | MySQL numeric-code and message-based classification were extracted into focused helpers; all characterization tests remained green. |
 | Regression | `go test ./internal/mcp -count=1` passed after the implementation and response-message refinement. |
 
 ## Test specification
@@ -42,7 +44,7 @@ The regression uses a deterministic MySQL-compatible driver error through `sqlmo
 - `go test ./...` — PASS
 - `go vet ./...` — PASS
 - `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./... --timeout=5m` — PASS, 0 issues
-- `go test -cover ./...` — PASS; `internal/mcp` coverage 86.0%
+- `go test -cover ./...` — PASS; `internal/mcp` coverage 86.1%
 - `go build -o ./tmp/mcp-server ./cmd/server/main.go` — PASS
 - `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` — PASS, no called vulnerabilities
 

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -272,9 +272,14 @@ func (a *ErrorAnalyzer) handleColumnNotFound(context map[string]interface{}) *St
 		tableName = tn
 	}
 
+	message := fmt.Sprintf("Column '%s' not found", columnName)
+	if tableName != "" {
+		message = fmt.Sprintf("Column '%s' not found in table '%s'", columnName, tableName)
+	}
+
 	err := NewStructuredError(
 		ErrorCodeColumnNotFound,
-		fmt.Sprintf("Column '%s' not found in table '%s'", columnName, tableName),
+		message,
 		fmt.Sprint(context["error"]),
 	).WithContext("column_name", columnName).WithContext("table_name", tableName)
 

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -489,10 +489,10 @@ func (a *ErrorAnalyzer) handleReadOnlyViolation(context map[string]interface{}) 
 func extractTableName(errMsg string) string {
 	// Try to extract table name from common error patterns
 	patterns := []string{
-		`table ['"]?(\w+)['"]?`,
-		`relation ['"]?(\w+)['"]?`,
-		`no such table: (\w+)`,
-		`Table '(\w+)'`,
+		`table ['"]?([^'"\s]+)['"]?`,
+		`relation ['"]?([^'"\s]+)['"]?`,
+		`no such table: ([^\s]+)`,
+		`Table '([^']+)'`,
 	}
 
 	for _, pattern := range patterns {
@@ -597,6 +597,11 @@ func (a *ErrorAnalyzer) handleDatabaseNotFound(context map[string]interface{}) *
 	dbName := ""
 	if dn, ok := context["database_name"].(string); ok {
 		dbName = dn
+	}
+	if dbName == "" {
+		if dn, ok := context["database"].(string); ok {
+			dbName = dn
+		}
 	}
 
 	err := NewStructuredError(

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -124,51 +124,64 @@ func (a *ErrorAnalyzer) AnalyzeError(err error, context map[string]interface{}) 
 	}
 
 	errMsg := err.Error()
+	errorContext := make(map[string]interface{}, len(context)+1)
+	for key, value := range context {
+		errorContext[key] = value
+	}
+	errorContext["error"] = errMsg
+
 	log.JSONLog("debug", "Analyzing error", map[string]interface{}{
 		"error":   errMsg,
-		"context": context,
+		"context": errorContext,
 	})
+
+	normalizedErrMsg := strings.ToLower(errMsg)
 
 	// Check for specific error patterns
 	switch {
-	case strings.Contains(errMsg, "profile not found"):
-		return a.handleProfileNotFound(context)
+	case strings.Contains(normalizedErrMsg, "profile not found"):
+		return a.handleProfileNotFound(errorContext)
 
-	case strings.Contains(errMsg, "no such table") || strings.Contains(errMsg, "table") && strings.Contains(errMsg, errorTextDoesNotExist):
-		return a.handleTableNotFound(context)
+	case strings.Contains(normalizedErrMsg, "no such table") ||
+		strings.Contains(normalizedErrMsg, "unknown table") ||
+		strings.Contains(normalizedErrMsg, "table") && strings.Contains(normalizedErrMsg, errorTextDoesNotExist):
+		return a.handleTableNotFound(errorContext)
 
-	case strings.Contains(errMsg, "no such column") || strings.Contains(errMsg, "column") && strings.Contains(errMsg, errorTextDoesNotExist):
-		return a.handleColumnNotFound(context)
+	case strings.Contains(normalizedErrMsg, "no such column") ||
+		strings.Contains(normalizedErrMsg, "unknown column") ||
+		strings.Contains(normalizedErrMsg, "column") && strings.Contains(normalizedErrMsg, errorTextDoesNotExist):
+		return a.handleColumnNotFound(errorContext)
 
-	case strings.Contains(errMsg, "syntax error") || strings.Contains(errMsg, "SQL syntax"):
-		return a.handleSQLSyntaxError(context)
+	case strings.Contains(normalizedErrMsg, "syntax error") || strings.Contains(normalizedErrMsg, "sql syntax"):
+		return a.handleSQLSyntaxError(errorContext)
 
-	case strings.Contains(errMsg, "denied") || strings.Contains(errMsg, "permission"):
-		return a.handlePermissionDenied(context)
+	case strings.Contains(normalizedErrMsg, "denied") || strings.Contains(normalizedErrMsg, "permission"):
+		return a.handlePermissionDenied(errorContext)
 
-	case strings.Contains(errMsg, "read-only") || strings.Contains(errMsg, "readonly"):
-		return a.handleReadOnlyViolation(context)
+	case strings.Contains(normalizedErrMsg, "read-only") || strings.Contains(normalizedErrMsg, "readonly"):
+		return a.handleReadOnlyViolation(errorContext)
 
-	case strings.Contains(errMsg, "constraint") || strings.Contains(errMsg, "foreign key"):
-		return a.handleConstraintViolation(context)
+	case strings.Contains(normalizedErrMsg, "constraint") || strings.Contains(normalizedErrMsg, "foreign key"):
+		return a.handleConstraintViolation(errorContext)
 
-	case strings.Contains(errMsg, "connection") || strings.Contains(errMsg, "connect"):
-		return a.handleConnectionError(context)
+	case strings.Contains(normalizedErrMsg, "connection") || strings.Contains(normalizedErrMsg, "connect"):
+		return a.handleConnectionError(errorContext)
 
-	case strings.Contains(errMsg, "database") && (strings.Contains(errMsg, errorTextDoesNotExist) || strings.Contains(errMsg, "not found")):
-		return a.handleDatabaseNotFound(context)
+	case strings.Contains(normalizedErrMsg, "database") &&
+		(strings.Contains(normalizedErrMsg, errorTextDoesNotExist) || strings.Contains(normalizedErrMsg, "not found")):
+		return a.handleDatabaseNotFound(errorContext)
 
-	case strings.Contains(errMsg, "data type") || strings.Contains(errMsg, "type mismatch"):
-		return a.handleDataTypeMismatch(context)
+	case strings.Contains(normalizedErrMsg, "data type") || strings.Contains(normalizedErrMsg, "type mismatch"):
+		return a.handleDataTypeMismatch(errorContext)
 
-	case strings.Contains(errMsg, "unsupported db_type"):
-		return a.handleUnsupportedDatabase(context)
+	case strings.Contains(normalizedErrMsg, "unsupported db_type"):
+		return a.handleUnsupportedDatabase(errorContext)
 
-	case strings.Contains(errMsg, "decrypt password") || strings.Contains(errMsg, "decrypt password failed"):
-		return a.handleDecryptionFailed(context)
+	case strings.Contains(normalizedErrMsg, "decrypt password") || strings.Contains(normalizedErrMsg, "decrypt password failed"):
+		return a.handleDecryptionFailed(errorContext)
 
 	default:
-		return a.handleUnknownError(context)
+		return a.handleUnknownError(errorContext)
 	}
 }
 
@@ -262,7 +275,7 @@ func (a *ErrorAnalyzer) handleColumnNotFound(context map[string]interface{}) *St
 	err := NewStructuredError(
 		ErrorCodeColumnNotFound,
 		fmt.Sprintf("Column '%s' not found in table '%s'", columnName, tableName),
-		"The specified column does not exist in the table",
+		fmt.Sprint(context["error"]),
 	).WithContext("column_name", columnName).WithContext("table_name", tableName)
 
 	profileName := ""
@@ -412,10 +425,10 @@ func extractTableName(errMsg string) string {
 func extractColumnName(errMsg string) string {
 	// Try to extract column name from common error patterns
 	patterns := []string{
-		`column ['"]?(\w+)['"]?`,
-		`field ['"]?(\w+)['"]?`,
-		`no such column: (\w+)`,
-		`Column '(\w+)'`,
+		`column ['"]?([^'":\s]+)['"]?`,
+		`field ['"]?([^'":\s]+)['"]?`,
+		`no such column: ([^\s]+)`,
+		`Column '([^']+)'`,
 	}
 
 	for _, pattern := range patterns {

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -6,9 +6,12 @@ package mcp
 import (
 	"database-mcp-provider/internal/log"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/go-sql-driver/mysql"
 )
 
 // ErrorCode represents standardized error codes for the MCP server
@@ -46,6 +49,8 @@ const (
 )
 
 const errorTextDoesNotExist = "does not exist"
+
+var duplicateEntryValuePattern = regexp.MustCompile(`(?i)(duplicate entry )'.*'( for key )`)
 
 // ErrorSuggestion represents a suggestion to fix an error
 type ErrorSuggestion struct {
@@ -128,7 +133,10 @@ func (a *ErrorAnalyzer) AnalyzeError(err error, context map[string]interface{}) 
 	for key, value := range context {
 		errorContext[key] = value
 	}
-	errorContext["error"] = errMsg
+	if isSQLExecutionContext(errorContext) {
+		errorContext["error"] = safeSQLDriverError(err)
+	}
+	addDatabaseErrorMetadata(err, errorContext)
 
 	log.JSONLog("debug", "Analyzing error", map[string]interface{}{
 		"error":   errMsg,
@@ -136,53 +144,117 @@ func (a *ErrorAnalyzer) AnalyzeError(err error, context map[string]interface{}) 
 	})
 
 	normalizedErrMsg := strings.ToLower(errMsg)
+	databaseErrorCode, _ := errorContext["database_error_code"].(int)
 
 	// Check for specific error patterns
+	var structuredErr *StructuredError
 	switch {
+	case databaseErrorCode == 1054:
+		structuredErr = a.handleColumnNotFound(errorContext)
+
+	case databaseErrorCode == 1146:
+		structuredErr = a.handleTableNotFound(errorContext)
+
+	case databaseErrorCode == 1064:
+		structuredErr = a.handleSQLSyntaxError(errorContext)
+
+	case databaseErrorCode == 1044 || databaseErrorCode == 1045 || databaseErrorCode == 1142:
+		structuredErr = a.handlePermissionDenied(errorContext)
+
+	case databaseErrorCode == 1062 || databaseErrorCode == 1451 || databaseErrorCode == 1452:
+		structuredErr = a.handleConstraintViolation(errorContext)
+
+	case databaseErrorCode == 1049:
+		structuredErr = a.handleDatabaseNotFound(errorContext)
+
 	case strings.Contains(normalizedErrMsg, "profile not found"):
-		return a.handleProfileNotFound(errorContext)
+		structuredErr = a.handleProfileNotFound(errorContext)
 
 	case strings.Contains(normalizedErrMsg, "no such table") ||
 		strings.Contains(normalizedErrMsg, "unknown table") ||
 		strings.Contains(normalizedErrMsg, "table") && strings.Contains(normalizedErrMsg, errorTextDoesNotExist):
-		return a.handleTableNotFound(errorContext)
+		structuredErr = a.handleTableNotFound(errorContext)
 
 	case strings.Contains(normalizedErrMsg, "no such column") ||
 		strings.Contains(normalizedErrMsg, "unknown column") ||
 		strings.Contains(normalizedErrMsg, "column") && strings.Contains(normalizedErrMsg, errorTextDoesNotExist):
-		return a.handleColumnNotFound(errorContext)
+		structuredErr = a.handleColumnNotFound(errorContext)
 
 	case strings.Contains(normalizedErrMsg, "syntax error") || strings.Contains(normalizedErrMsg, "sql syntax"):
-		return a.handleSQLSyntaxError(errorContext)
+		structuredErr = a.handleSQLSyntaxError(errorContext)
 
 	case strings.Contains(normalizedErrMsg, "denied") || strings.Contains(normalizedErrMsg, "permission"):
-		return a.handlePermissionDenied(errorContext)
+		structuredErr = a.handlePermissionDenied(errorContext)
 
 	case strings.Contains(normalizedErrMsg, "read-only") || strings.Contains(normalizedErrMsg, "readonly"):
-		return a.handleReadOnlyViolation(errorContext)
+		structuredErr = a.handleReadOnlyViolation(errorContext)
 
 	case strings.Contains(normalizedErrMsg, "constraint") || strings.Contains(normalizedErrMsg, "foreign key"):
-		return a.handleConstraintViolation(errorContext)
+		structuredErr = a.handleConstraintViolation(errorContext)
 
 	case strings.Contains(normalizedErrMsg, "connection") || strings.Contains(normalizedErrMsg, "connect"):
-		return a.handleConnectionError(errorContext)
+		structuredErr = a.handleConnectionError(errorContext)
 
 	case strings.Contains(normalizedErrMsg, "database") &&
 		(strings.Contains(normalizedErrMsg, errorTextDoesNotExist) || strings.Contains(normalizedErrMsg, "not found")):
-		return a.handleDatabaseNotFound(errorContext)
+		structuredErr = a.handleDatabaseNotFound(errorContext)
 
 	case strings.Contains(normalizedErrMsg, "data type") || strings.Contains(normalizedErrMsg, "type mismatch"):
-		return a.handleDataTypeMismatch(errorContext)
+		structuredErr = a.handleDataTypeMismatch(errorContext)
 
 	case strings.Contains(normalizedErrMsg, "unsupported db_type"):
-		return a.handleUnsupportedDatabase(errorContext)
+		structuredErr = a.handleUnsupportedDatabase(errorContext)
 
 	case strings.Contains(normalizedErrMsg, "decrypt password") || strings.Contains(normalizedErrMsg, "decrypt password failed"):
-		return a.handleDecryptionFailed(errorContext)
+		structuredErr = a.handleDecryptionFailed(errorContext)
 
+	case isSQLExecutionContext(errorContext):
+		structuredErr = a.handleSQLExecutionError(errorContext)
 	default:
-		return a.handleUnknownError(errorContext)
+		structuredErr = a.handleUnknownError(errorContext)
 	}
+	return withDatabaseErrorMetadata(structuredErr, errorContext)
+}
+
+func isSQLExecutionContext(context map[string]interface{}) bool {
+	operation, _ := context["operation"].(string)
+	switch operation {
+	case "query", "prepared_query", "prepare_statement", "execute_sql", "prepared_exec", "scan_rows":
+		return true
+	default:
+		return false
+	}
+}
+
+func addDatabaseErrorMetadata(err error, context map[string]interface{}) {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return
+	}
+	context["database_error_code"] = int(mysqlErr.Number)
+	sqlState := strings.TrimRight(string(mysqlErr.SQLState[:]), "\x00")
+	if sqlState != "" {
+		context["sql_state"] = sqlState
+	}
+}
+
+func safeSQLDriverError(err error) string {
+	message := err.Error()
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+		return duplicateEntryValuePattern.ReplaceAllString(message, "${1}'<redacted>'${2}")
+	}
+	return message
+}
+
+func withDatabaseErrorMetadata(structuredErr *StructuredError, context map[string]interface{}) *StructuredError {
+	if code, ok := context["database_error_code"]; ok {
+		structuredErr.WithContext("database_error_code", code) //nolint:errcheck // Builder modifies in-place
+	}
+	if sqlState, ok := context["sql_state"]; ok {
+		structuredErr.WithContext("sql_state", sqlState) //nolint:errcheck // Builder modifies in-place
+	}
+	return structuredErr
 }
 
 // handleProfileNotFound handles profile not found errors
@@ -225,7 +297,7 @@ func (a *ErrorAnalyzer) handleTableNotFound(context map[string]interface{}) *Str
 	err := NewStructuredError(
 		ErrorCodeTableNotFound,
 		fmt.Sprintf("Table '%s' not found", tableName),
-		"The specified table does not exist in the database",
+		errorDetails(context, "The specified table does not exist in the database"),
 	).WithContext("table_name", tableName)
 
 	profileName := ""
@@ -280,7 +352,7 @@ func (a *ErrorAnalyzer) handleColumnNotFound(context map[string]interface{}) *St
 	err := NewStructuredError(
 		ErrorCodeColumnNotFound,
 		message,
-		fmt.Sprint(context["error"]),
+		errorDetails(context, "The specified column does not exist in the table"),
 	).WithContext("column_name", columnName).WithContext("table_name", tableName)
 
 	profileName := ""
@@ -319,7 +391,7 @@ func (a *ErrorAnalyzer) handleSQLSyntaxError(context map[string]interface{}) *St
 	err := NewStructuredError(
 		ErrorCodeSQLSyntax,
 		"SQL syntax error",
-		fmt.Sprint(context["error"]),
+		errorDetails(context, "The SQL statement is invalid"),
 	)
 
 	sql := ""
@@ -452,7 +524,7 @@ func (a *ErrorAnalyzer) handlePermissionDenied(context map[string]interface{}) *
 	err := NewStructuredError(
 		ErrorCodePermissionDenied,
 		"Permission denied",
-		fmt.Sprint(context["error"]),
+		errorDetails(context, "The database user does not have permission for this operation"),
 	)
 
 	err.WithSuggestions( //nolint:errcheck // Builder modifies in-place, return value not needed
@@ -473,7 +545,7 @@ func (a *ErrorAnalyzer) handleConstraintViolation(context map[string]interface{}
 	err := NewStructuredError(
 		ErrorCodeConstraintViolation,
 		"Database constraint violation",
-		fmt.Sprint(context["error"]),
+		errorDetails(context, "The operation violates a database constraint"),
 	)
 
 	err.WithSuggestions( //nolint:errcheck // Builder modifies in-place, return value not needed
@@ -494,7 +566,7 @@ func (a *ErrorAnalyzer) handleConnectionError(context map[string]interface{}) *S
 	err := NewStructuredError(
 		ErrorCodeConnectionFailed,
 		"Database connection failed",
-		fmt.Sprint(context["error"]),
+		errorDetails(context, "Unable to connect to the configured database"),
 	)
 
 	err.WithSuggestions( //nolint:errcheck // Builder modifies in-place, return value not needed
@@ -524,7 +596,7 @@ func (a *ErrorAnalyzer) handleDatabaseNotFound(context map[string]interface{}) *
 	err := NewStructuredError(
 		ErrorCodeDatabaseNotFound,
 		fmt.Sprintf("Database '%s' not found", dbName),
-		"The specified database does not exist",
+		errorDetails(context, "The specified database does not exist"),
 	).WithContext("database_name", dbName)
 
 	profileName := ""
@@ -551,7 +623,7 @@ func (a *ErrorAnalyzer) handleDataTypeMismatch(context map[string]interface{}) *
 	err := NewStructuredError(
 		ErrorCodeDataTypeMismatch,
 		"Data type mismatch",
-		fmt.Sprint(context["error"]),
+		errorDetails(context, "A value does not match the required database type"),
 	)
 
 	tableName := ""
@@ -644,7 +716,7 @@ func (a *ErrorAnalyzer) handleUnknownError(context map[string]interface{}) *Stru
 	return NewStructuredError(
 		ErrorCodeUnknownError,
 		"An unexpected error occurred",
-		fmt.Sprint(context["error"]),
+		errorDetails(context, "No additional error details are available"),
 	).WithSuggestions(
 		ErrorSuggestion{
 			Action:      "Check error details",
@@ -655,4 +727,28 @@ func (a *ErrorAnalyzer) handleUnknownError(context map[string]interface{}) *Stru
 			Description: "Ensure all required parameters are provided correctly",
 		},
 	)
+}
+
+func (a *ErrorAnalyzer) handleSQLExecutionError(context map[string]interface{}) *StructuredError {
+	return NewStructuredError(
+		ErrorCodeSQLExecutionError,
+		"SQL execution failed",
+		errorDetails(context, "The database operation failed"),
+	).WithSuggestions(
+		ErrorSuggestion{
+			Action:      "Check error details",
+			Description: "Review the database error message for more information",
+		},
+		ErrorSuggestion{
+			Action:      "Verify the SQL statement",
+			Description: "Ensure the statement and referenced database objects are valid",
+		},
+	)
+}
+
+func errorDetails(context map[string]interface{}, fallback string) string {
+	if details, ok := context["error"].(string); ok && details != "" {
+		return details
+	}
+	return fallback
 }

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -146,74 +146,80 @@ func (a *ErrorAnalyzer) AnalyzeError(err error, context map[string]interface{}) 
 	normalizedErrMsg := strings.ToLower(errMsg)
 	databaseErrorCode, _ := errorContext["database_error_code"].(int)
 
-	// Check for specific error patterns
-	var structuredErr *StructuredError
+	structuredErr := a.classifyMySQLError(databaseErrorCode, errorContext)
+	if structuredErr == nil {
+		structuredErr = a.classifyErrorMessage(normalizedErrMsg, errorContext)
+	}
+	return withDatabaseErrorMetadata(structuredErr, errorContext)
+}
+
+func (a *ErrorAnalyzer) classifyMySQLError(code int, context map[string]interface{}) *StructuredError {
+	switch code {
+	case 1054:
+		return a.handleColumnNotFound(context)
+	case 1146:
+		return a.handleTableNotFound(context)
+	case 1064:
+		return a.handleSQLSyntaxError(context)
+	case 1044, 1045, 1142:
+		return a.handlePermissionDenied(context)
+	case 1062, 1451, 1452:
+		return a.handleConstraintViolation(context)
+	case 1049:
+		return a.handleDatabaseNotFound(context)
+	default:
+		return nil
+	}
+}
+
+func (a *ErrorAnalyzer) classifyErrorMessage(normalizedErrMsg string, context map[string]interface{}) *StructuredError {
 	switch {
-	case databaseErrorCode == 1054:
-		structuredErr = a.handleColumnNotFound(errorContext)
-
-	case databaseErrorCode == 1146:
-		structuredErr = a.handleTableNotFound(errorContext)
-
-	case databaseErrorCode == 1064:
-		structuredErr = a.handleSQLSyntaxError(errorContext)
-
-	case databaseErrorCode == 1044 || databaseErrorCode == 1045 || databaseErrorCode == 1142:
-		structuredErr = a.handlePermissionDenied(errorContext)
-
-	case databaseErrorCode == 1062 || databaseErrorCode == 1451 || databaseErrorCode == 1452:
-		structuredErr = a.handleConstraintViolation(errorContext)
-
-	case databaseErrorCode == 1049:
-		structuredErr = a.handleDatabaseNotFound(errorContext)
-
 	case strings.Contains(normalizedErrMsg, "profile not found"):
-		structuredErr = a.handleProfileNotFound(errorContext)
+		return a.handleProfileNotFound(context)
 
 	case strings.Contains(normalizedErrMsg, "no such table") ||
 		strings.Contains(normalizedErrMsg, "unknown table") ||
 		strings.Contains(normalizedErrMsg, "table") && strings.Contains(normalizedErrMsg, errorTextDoesNotExist):
-		structuredErr = a.handleTableNotFound(errorContext)
+		return a.handleTableNotFound(context)
 
 	case strings.Contains(normalizedErrMsg, "no such column") ||
 		strings.Contains(normalizedErrMsg, "unknown column") ||
 		strings.Contains(normalizedErrMsg, "column") && strings.Contains(normalizedErrMsg, errorTextDoesNotExist):
-		structuredErr = a.handleColumnNotFound(errorContext)
+		return a.handleColumnNotFound(context)
 
 	case strings.Contains(normalizedErrMsg, "syntax error") || strings.Contains(normalizedErrMsg, "sql syntax"):
-		structuredErr = a.handleSQLSyntaxError(errorContext)
+		return a.handleSQLSyntaxError(context)
 
 	case strings.Contains(normalizedErrMsg, "denied") || strings.Contains(normalizedErrMsg, "permission"):
-		structuredErr = a.handlePermissionDenied(errorContext)
+		return a.handlePermissionDenied(context)
 
 	case strings.Contains(normalizedErrMsg, "read-only") || strings.Contains(normalizedErrMsg, "readonly"):
-		structuredErr = a.handleReadOnlyViolation(errorContext)
+		return a.handleReadOnlyViolation(context)
 
 	case strings.Contains(normalizedErrMsg, "constraint") || strings.Contains(normalizedErrMsg, "foreign key"):
-		structuredErr = a.handleConstraintViolation(errorContext)
+		return a.handleConstraintViolation(context)
 
 	case strings.Contains(normalizedErrMsg, "connection") || strings.Contains(normalizedErrMsg, "connect"):
-		structuredErr = a.handleConnectionError(errorContext)
+		return a.handleConnectionError(context)
 
 	case strings.Contains(normalizedErrMsg, "database") &&
 		(strings.Contains(normalizedErrMsg, errorTextDoesNotExist) || strings.Contains(normalizedErrMsg, "not found")):
-		structuredErr = a.handleDatabaseNotFound(errorContext)
+		return a.handleDatabaseNotFound(context)
 
 	case strings.Contains(normalizedErrMsg, "data type") || strings.Contains(normalizedErrMsg, "type mismatch"):
-		structuredErr = a.handleDataTypeMismatch(errorContext)
+		return a.handleDataTypeMismatch(context)
 
 	case strings.Contains(normalizedErrMsg, "unsupported db_type"):
-		structuredErr = a.handleUnsupportedDatabase(errorContext)
+		return a.handleUnsupportedDatabase(context)
 
 	case strings.Contains(normalizedErrMsg, "decrypt password") || strings.Contains(normalizedErrMsg, "decrypt password failed"):
-		structuredErr = a.handleDecryptionFailed(errorContext)
+		return a.handleDecryptionFailed(context)
 
-	case isSQLExecutionContext(errorContext):
-		structuredErr = a.handleSQLExecutionError(errorContext)
+	case isSQLExecutionContext(context):
+		return a.handleSQLExecutionError(context)
 	default:
-		structuredErr = a.handleUnknownError(errorContext)
+		return a.handleUnknownError(context)
 	}
-	return withDatabaseErrorMetadata(structuredErr, errorContext)
 }
 
 func isSQLExecutionContext(context map[string]interface{}) bool {

--- a/internal/mcp/issue_116_test.go
+++ b/internal/mcp/issue_116_test.go
@@ -57,6 +57,9 @@ func TestQueryRowsForSQLPreservesMySQLUnknownColumnError(t *testing.T) {
 	if structured.ErrorCode != ErrorCodeColumnNotFound {
 		t.Fatalf("expected %s, got %s", ErrorCodeColumnNotFound, structured.ErrorCode)
 	}
+	if structured.Message != "Column 'u.userName' not found" {
+		t.Fatalf("unexpected error message %q", structured.Message)
+	}
 	if structured.Details != driverErr.Error() {
 		t.Fatalf("expected driver details %q, got %q", driverErr.Error(), structured.Details)
 	}

--- a/internal/mcp/issue_116_test.go
+++ b/internal/mcp/issue_116_test.go
@@ -1,0 +1,69 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"testing"
+
+	"database-mcp-provider/internal/config"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestQueryRowsForSQLPreservesMySQLUnknownColumnError(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sqlmock: %v", err)
+	}
+	defer conn.Close()
+
+	const query = "SELECT u.userName FROM ohrm_user u"
+	driverErr := errors.New("Error 1054 (42S22): Unknown column 'u.userName' in 'field list'")
+	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnError(driverErr)
+
+	server := &MCPServer{errorAnalyzer: NewErrorAnalyzer("")}
+	rows, result, queryErr := server.queryRowsForSQL(
+		context.Background(),
+		conn,
+		ExecuteSQLParams{ProfileName: "hrm-mariadb", SQL: query},
+		&config.Profile{DBType: "mysql"},
+	)
+
+	if rows != nil {
+		t.Fatal("expected no rows after query failure")
+	}
+	if queryErr != nil {
+		t.Fatalf("expected structured error result, got Go error: %v", queryErr)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("expected MCP error result, got %#v", result)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("expected one error content item, got %d", len(result.Content))
+	}
+
+	text, ok := result.Content[0].(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("expected text error content, got %T", result.Content[0])
+	}
+
+	var structured StructuredError
+	if err := json.Unmarshal([]byte(text.Text), &structured); err != nil {
+		t.Fatalf("decode structured error: %v", err)
+	}
+	if structured.ErrorCode != ErrorCodeColumnNotFound {
+		t.Fatalf("expected %s, got %s", ErrorCodeColumnNotFound, structured.ErrorCode)
+	}
+	if structured.Details != driverErr.Error() {
+		t.Fatalf("expected driver details %q, got %q", driverErr.Error(), structured.Details)
+	}
+	if structured.Details == "<nil>" {
+		t.Fatal("database error details must not serialize as <nil>")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}

--- a/internal/mcp/issue_116_test.go
+++ b/internal/mcp/issue_116_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"regexp"
+	"strings"
 	"testing"
 
 	"database-mcp-provider/internal/config"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -21,7 +23,11 @@ func TestQueryRowsForSQLPreservesMySQLUnknownColumnError(t *testing.T) {
 	defer conn.Close()
 
 	const query = "SELECT u.userName FROM ohrm_user u"
-	driverErr := errors.New("Error 1054 (42S22): Unknown column 'u.userName' in 'field list'")
+	driverErr := &mysql.MySQLError{
+		Number:   1054,
+		SQLState: [5]byte{'4', '2', 'S', '2', '2'},
+		Message:  "Unknown column 'u.userName' in 'field list'",
+	}
 	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnError(driverErr)
 
 	server := &MCPServer{errorAnalyzer: NewErrorAnalyzer("")}
@@ -66,7 +72,121 @@ func TestQueryRowsForSQLPreservesMySQLUnknownColumnError(t *testing.T) {
 	if structured.Details == "<nil>" {
 		t.Fatal("database error details must not serialize as <nil>")
 	}
+	if structured.Context["database_error_code"] != float64(1054) {
+		t.Fatalf("expected database error code 1054, got %#v", structured.Context["database_error_code"])
+	}
+	if structured.Context["sql_state"] != "42S22" {
+		t.Fatalf("expected SQLSTATE 42S22, got %#v", structured.Context["sql_state"])
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations: %v", err)
 	}
+}
+
+func TestTryExecuteSQLQueryPreservesRowIterationError(t *testing.T) {
+	conn, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sqlmock: %v", err)
+	}
+	defer conn.Close()
+
+	const query = "SELECT 1"
+	driverErr := errors.New("stream interrupted while reading rows")
+	rows := sqlmock.NewRows([]string{"value"}).
+		AddRow(1).
+		RowError(0, driverErr)
+	mock.ExpectQuery(regexp.QuoteMeta(query)).WillReturnRows(rows)
+
+	server := &MCPServer{errorAnalyzer: NewErrorAnalyzer("")}
+	_, handled, result, queryErr := server.tryExecuteSQLQuery(
+		context.Background(),
+		conn,
+		ExecuteSQLParams{ProfileName: "test-db", SQL: query},
+		&config.Profile{DBType: "mysql"},
+	)
+
+	if handled {
+		t.Fatal("row iteration failure must not be reported as a handled success")
+	}
+	if queryErr != nil {
+		t.Fatalf("expected structured error result, got Go error: %v", queryErr)
+	}
+	if result == nil || !result.IsError {
+		t.Fatalf("expected MCP error result, got %#v", result)
+	}
+
+	structured := decodeStructuredErrorResult(t, result)
+	if structured.ErrorCode != ErrorCodeSQLExecutionError {
+		t.Fatalf("expected %s, got %s", ErrorCodeSQLExecutionError, structured.ErrorCode)
+	}
+	if structured.Details != driverErr.Error() {
+		t.Fatalf("expected driver details %q, got %q", driverErr.Error(), structured.Details)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestAnalyzeErrorDoesNotExposeNonSQLConnectionDetails(t *testing.T) {
+	const sensitiveError = "dial tcp 10.0.0.5:3306 password=secret: connection refused"
+
+	structured := NewErrorAnalyzer("").AnalyzeError(
+		errors.New(sensitiveError),
+		map[string]interface{}{"operation": "connect", "profile_name": "private-db"},
+	)
+
+	if structured.ErrorCode != ErrorCodeConnectionFailed {
+		t.Fatalf("expected %s, got %s", ErrorCodeConnectionFailed, structured.ErrorCode)
+	}
+	if structured.Details != "Unable to connect to the configured database" {
+		t.Fatalf("unexpected connection details %q", structured.Details)
+	}
+	if strings.Contains(structured.ToJSON(), "password=secret") {
+		t.Fatal("non-SQL connection errors must not expose raw sensitive details")
+	}
+}
+
+func TestAnalyzeErrorRedactsMySQLDuplicateEntryValue(t *testing.T) {
+	driverErr := &mysql.MySQLError{
+		Number:   1062,
+		SQLState: [5]byte{'2', '3', '0', '0', '0'},
+		Message:  "Duplicate entry 'O'Reilly@example.com' for key 'users.email'",
+	}
+
+	structured := NewErrorAnalyzer("").AnalyzeError(
+		driverErr,
+		map[string]interface{}{"operation": "prepared_exec", "profile_name": "app-db"},
+	)
+
+	if structured.ErrorCode != ErrorCodeConstraintViolation {
+		t.Fatalf("expected %s, got %s", ErrorCodeConstraintViolation, structured.ErrorCode)
+	}
+	if strings.Contains(structured.Details, "Reilly@example.com") {
+		t.Fatal("constraint details must not expose the conflicting value")
+	}
+	if !strings.Contains(structured.Details, "Duplicate entry '<redacted>'") {
+		t.Fatalf("expected redacted duplicate-entry details, got %q", structured.Details)
+	}
+	if structured.Context["database_error_code"] != 1062 {
+		t.Fatalf("expected database error code 1062, got %#v", structured.Context["database_error_code"])
+	}
+	if structured.Context["sql_state"] != "23000" {
+		t.Fatalf("expected SQLSTATE 23000, got %#v", structured.Context["sql_state"])
+	}
+}
+
+func decodeStructuredErrorResult(t *testing.T, result *mcpsdk.CallToolResult) StructuredError {
+	t.Helper()
+	if len(result.Content) != 1 {
+		t.Fatalf("expected one error content item, got %d", len(result.Content))
+	}
+	text, ok := result.Content[0].(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("expected text error content, got %T", result.Content[0])
+	}
+	var structured StructuredError
+	if err := json.Unmarshal([]byte(text.Text), &structured); err != nil {
+		t.Fatalf("decode structured error: %v", err)
+	}
+	return structured
 }

--- a/internal/mcp/issue_116_test.go
+++ b/internal/mcp/issue_116_test.go
@@ -175,6 +175,68 @@ func TestAnalyzeErrorRedactsMySQLDuplicateEntryValue(t *testing.T) {
 	}
 }
 
+func TestAnalyzeErrorExtractsQualifiedMySQLTableName(t *testing.T) {
+	driverErr := &mysql.MySQLError{
+		Number:   1146,
+		SQLState: [5]byte{'4', '2', 'S', '0', '2'},
+		Message:  "Table 'hrm.ohrm_user' doesn't exist",
+	}
+
+	structured := NewErrorAnalyzer("").AnalyzeError(
+		driverErr,
+		map[string]interface{}{"operation": "query", "profile_name": "hrm-mariadb"},
+	)
+
+	if structured.ErrorCode != ErrorCodeTableNotFound {
+		t.Fatalf("expected %s, got %s", ErrorCodeTableNotFound, structured.ErrorCode)
+	}
+	if structured.Message != "Table 'hrm.ohrm_user' not found" {
+		t.Fatalf("unexpected error message %q", structured.Message)
+	}
+	if structured.Context["table_name"] != "hrm.ohrm_user" {
+		t.Fatalf("expected qualified table name, got %#v", structured.Context["table_name"])
+	}
+	if structured.Context["database_error_code"] != 1146 {
+		t.Fatalf("expected database error code 1146, got %#v", structured.Context["database_error_code"])
+	}
+	if structured.Context["sql_state"] != "42S02" {
+		t.Fatalf("expected SQLSTATE 42S02, got %#v", structured.Context["sql_state"])
+	}
+}
+
+func TestAnalyzeErrorPreservesDatabaseNameForMySQL1049(t *testing.T) {
+	driverErr := &mysql.MySQLError{
+		Number:   1049,
+		SQLState: [5]byte{'4', '2', '0', '0', '0'},
+		Message:  "Unknown database 'missing_db'",
+	}
+
+	structured := NewErrorAnalyzer("").AnalyzeError(
+		driverErr,
+		map[string]interface{}{
+			"operation":    "connect",
+			"profile_name": "hrm-mariadb",
+			"database":     "missing_db",
+		},
+	)
+
+	if structured.ErrorCode != ErrorCodeDatabaseNotFound {
+		t.Fatalf("expected %s, got %s", ErrorCodeDatabaseNotFound, structured.ErrorCode)
+	}
+	if structured.Message != "Database 'missing_db' not found" {
+		t.Fatalf("unexpected error message %q", structured.Message)
+	}
+	if structured.Details != "The specified database does not exist" {
+		t.Fatalf("unexpected database details %q", structured.Details)
+	}
+	if structured.Context["database_name"] != "missing_db" {
+		t.Fatalf("expected database_name context, got %#v", structured.Context["database_name"])
+	}
+	if strings.Contains(structured.ToJSON(), driverErr.Error()) {
+		t.Fatal("non-SQL database diagnostics must not expose raw driver details")
+	}
+}
+
 func decodeStructuredErrorResult(t *testing.T, result *mcpsdk.CallToolResult) StructuredError {
 	t.Helper()
 	if len(result.Content) != 1 {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2604,7 +2604,13 @@ func (s *MCPServer) tryExecuteSQLQuery(
 
 	result, err := scanExecuteSQLRows(ctx, conn, p.SQL, rows)
 	if err != nil {
-		return ExecuteSQLResult{}, false, nil, err
+		structErr := s.errorAnalyzer.AnalyzeError(err, map[string]interface{}{
+			"profile_name": p.ProfileName,
+			"sql":          p.SQL,
+			"operation":    "scan_rows",
+			"db_type":      prof.DBType,
+		})
+		return ExecuteSQLResult{}, false, errorResult(structErr), nil
 	}
 	return result, true, nil, nil
 }
@@ -2672,6 +2678,9 @@ func scanExecuteSQLRows(ctx context.Context, conn *sql.DB, sqlText string, rows 
 		}
 		normalizeQueryRowValues(row, cols, typeMap)
 		results = append(results, row)
+	}
+	if err := rows.Err(); err != nil {
+		return ExecuteSQLResult{}, err
 	}
 	return ExecuteSQLResult{Columns: cols, Rows: results}, nil
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2619,7 +2619,13 @@ func (s *MCPServer) queryRowsForSQL(
 		rows, err := conn.QueryContext(ctx, p.SQL)
 		if err != nil {
 			log.JSONLog("error", "Query failed", map[string]interface{}{"sql": p.SQL, "params": p.Params, "error": err})
-			return nil, nil, nil
+			structErr := s.errorAnalyzer.AnalyzeError(err, map[string]interface{}{
+				"profile_name": p.ProfileName,
+				"sql":          p.SQL,
+				"operation":    "query",
+				"db_type":      prof.DBType,
+			})
+			return nil, errorResult(structErr), nil
 		}
 		return rows, nil, nil
 	}


### PR DESCRIPTION
## Summary

- preserve database-driver diagnostics for `execute-sql` failures
- expose MySQL/MariaDB errno and SQLSTATE metadata
- map common MySQL errors to stable MCP error codes
- handle delayed row-stream failures instead of returning partial success
- redact MySQL duplicate-entry values and avoid leaking raw non-SQL connection details
- add regression tests, examples, changelog notes, and TDD evidence

## Root cause

Direct `QueryContext` failures returned nil results and fell through to the statement-execution path. The error analyzer therefore received no underlying driver error and produced an opaque `UNKNOWN_ERROR` with `details: "<nil>"`. Row iteration errors were also not checked after scanning completed.

## Impact

MCP clients can now diagnose invalid SQL directly from the tool response. For MySQL/MariaDB, responses include stable error classification plus vendor errno and SQLSTATE when available.

Closes #116.

## Validation

- `go test ./...`
- `go vet ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./... --timeout=5m`
- `go test -cover ./...` (`internal/mcp`: 86.0%)
- `go build -o ./tmp/mcp-server ./cmd/server/main.go`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
