### PR TITLE
chore: bump version to v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v1.6.3] - 2026-06-26
+
 ### Fixed
 
 - Fixed `execute-sql` discarding direct and row-stream query errors and returning `UNKNOWN_ERROR` with `details: "<nil>"`. SQL driver details are now preserved, MySQL/MariaDB errno and SQLSTATE metadata are exposed, and unknown-column errors map to `COLUMN_NOT_FOUND`.
+- Fixed MySQL/MariaDB missing-table diagnostics for schema-qualified names such as `db.table`, preserving the full table name in `TABLE_NOT_FOUND` responses.
+- Fixed MySQL/MariaDB unknown-database diagnostics so `DATABASE_NOT_FOUND` responses preserve the configured target database name for connection and database-switch failures.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go](https://img.shields.io/badge/Go-1.26.0%2B-00ADD8?logo=Go&logoColor=white)](https://go.dev)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Version-v1.6.2-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.6.2)
+[![Version](https://img.shields.io/badge/Version-v1.6.3-blue.svg)](https://github.com/guyinwonder168/database-mcp-server/releases/tag/v1.6.3)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=guyinwonder168_database-mcp-server&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=guyinwonder168_database-mcp-server)
@@ -28,10 +28,10 @@ go build -o mcp-server ./cmd/server/main.go
 
 ```bash
 # Pull the release image
-docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.6.2
+docker pull ghcr.io/guyinwonder168/database-mcp-server:v1.6.3
 
 # Run with stdio transport
-docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.6.2
+docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.6.3
 ```
 
 ```bash
@@ -39,7 +39,7 @@ docker run --rm -i ghcr.io/guyinwonder168/database-mcp-server:v1.6.2
 mkdir -p ./.mcp-data
 docker run --rm -i \
   -v "$(pwd)/.mcp-data:/app" \
-  ghcr.io/guyinwonder168/database-mcp-server:v1.6.2
+  ghcr.io/guyinwonder168/database-mcp-server:v1.6.3
 ```
 
 Package registry: `https://github.com/guyinwonder168/database-mcp-server/pkgs/container/database-mcp-server`
@@ -190,7 +190,7 @@ go test ./internal/mcp -run "TestLoadLineage" -v  # Lineage edge tests
 
 ## 📊 Project Status
 
-- **Version:** v1.6.2
+- **Version:** v1.6.3
 - **Built with:** Various vibe coding tools
 - **Status:** Production Ready ✅
 - All 21 MCP tools are fully implemented and OpenAPI-aligned.

--- a/docs/mcp-openapi.yaml
+++ b/docs/mcp-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Database MCP Provider API
-  version: "1.6.2"
+  version: "1.6.3"
   description: |
     OpenAPI documentation for all MCP tools exposed by the Database MCP Provider.
     This enables LLMs and clients to discover and use all available actions programmatically.

--- a/docs/technical-specifications.md
+++ b/docs/technical-specifications.md
@@ -5,7 +5,7 @@
 Database MCP Server is a production MCP provider for SQL databases, built in Go.
 
 Current implementation baseline:
-- Runtime version: `v1.6.2`
+- Runtime version: `v1.6.3`
 - Registered tools: `21`
 - Go module baseline: `go 1.26` (`toolchain go1.26.1`)
 - MCP SDK: `github.com/modelcontextprotocol/go-sdk v1.2.0`

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -42,7 +42,7 @@ type MCPServer struct {
 	contextMgr    *ctxmgr.Manager
 }
 
-const MCPVersion = "v1.6.2"
+const MCPVersion = "v1.6.3"
 const MCPAuthor = "guyinwonder"
 
 const sqliteListTablesQuery = "SELECT name FROM sqlite_master WHERE type='table'"


### PR DESCRIPTION
## Summary

- Bump runtime version from `v1.6.2` to `v1.6.3`.
- Sync README badge, Docker image examples, and OpenAPI `info.version`.
- Add `v1.6.3` changelog notes for the execute-sql diagnostics fixes.
- Update technical specifications runtime version.

## Wiki

Updated and pushed the GitHub wiki with current `v1.6.3` install examples, version badge/history, and execute-sql troubleshooting notes.

Wiki commit: `6171421 docs: update wiki for v1.6.3`

## Validation

- `scripts/sync-version-from-server.sh`
- `source ~/.gvm/scripts/gvm && go test ./...`
- `source ~/.gvm/scripts/gvm && go vet ./...`
- `source ~/.gvm/scripts/gvm && go build -o ./tmp/mcp-server ./cmd/server/main.go`
- `source ~/.gvm/scripts/gvm && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./... --timeout=5m`
